### PR TITLE
fix(c8yscrn): Fix setting of screenshot target folder overwrite 

### DIFF
--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -371,6 +371,7 @@ export interface C8yScreenshotOptions {
   quiet: boolean;
   setup: ScreenshotSetup;
   init: boolean;
+  clear: boolean;
 }
 
 export type C8yScreenshotActionHandler = (

--- a/src/screenshot/config.ts
+++ b/src/screenshot/config.ts
@@ -1,15 +1,23 @@
 import { defineConfig } from "cypress";
 import { configureC8yScreenshotPlugin } from "../plugin";
 
+import debug from "debug";
+const log = debug("c8y:scrn:cypress");
+
 export default defineConfig({
   e2e: {
     baseUrl: "http://localhost:4200",
     supportFile: false,
     video: false,
-    videosFolder: "videos",
-    screenshotsFolder: "screenshots",
     setupNodeEvents(on, config) {
       configureC8yScreenshotPlugin(on, config);
+      on("task", {
+        "debug": (message: string) => {
+          log(message);
+          return null;
+        }
+      });
+  
       return config;
     },
   },

--- a/src/screenshot/helper.spec.ts
+++ b/src/screenshot/helper.spec.ts
@@ -3,7 +3,11 @@
 import * as yaml from "yaml";
 
 import { C8yAjvSchemaMatcher } from "../contrib/ajv";
-import { createInitConfig } from "./helper";
+import {
+  createInitConfig,
+  resolveConfigOptions,
+  resolveScreenshotFolder,
+} from "./helper";
 import schema from "./../screenshot/schema.json";
 
 jest.spyOn(process, "cwd").mockReturnValue("/home/user/test");
@@ -18,6 +22,120 @@ describe("startup", () => {
         expect(data).not.toBeNull();
         ajv.match(data, schema, true);
       }).not.toThrow();
+    });
+  });
+
+  describe("resolveScreenshotFolder", () => {
+    it("should throw error for current working directory", () => {
+      expect(() => {
+        resolveScreenshotFolder({
+          folder: ".",
+        });
+      }).toThrow(
+        `Please provide a screenshot folder path that does not resolve to the current working directory.`
+      );
+    });
+
+    it("should throw error for current working directory with absolute path", () => {
+      expect(() => {
+        resolveScreenshotFolder({
+          // use trailing slash
+          folder: "/home/user/test/",
+        });
+      }).toThrow(
+        `Please provide a screenshot folder path that does not resolve to the current working directory.`
+      );
+    });
+
+    it("should throw error for current working directory with path operations", () => {
+      expect(() => {
+        resolveScreenshotFolder({
+          // use trailing slash
+          folder: "/home/../home/user/test/",
+        });
+      }).toThrow(
+        `Please provide a screenshot folder path that does not resolve to the current working directory.`
+      );
+    });
+
+    it("should return folder for current working directory", () => {
+      expect(resolveScreenshotFolder({ folder: "c8yscrn" })).toBe(
+        "/home/user/test/c8yscrn"
+      );
+    });
+
+    it("should return absolute folder", () => {
+      expect(
+        resolveScreenshotFolder({ folder: "/my/path/to/c8yscrn/folder" })
+      ).toBe("/my/path/to/c8yscrn/folder");
+    });
+
+    it("should return folder for folder hierarchy", () => {
+      expect(resolveScreenshotFolder({ folder: "my/c8yscrn/folder" })).toBe(
+        "/home/user/test/my/c8yscrn/folder"
+      );
+    });
+  });
+
+  describe("resolveConfigOptions", () => {
+    it("should return default options", () => {
+      const options = resolveConfigOptions({});
+      expect(options.browser).toBe("chrome");
+      expect(options.quiet).toBe(true);
+      expect(options.testingType).toBe("e2e");
+      expect(options.config.e2e.baseUrl).toBe("http://localhost:8080");
+      expect(options.config.e2e.screenshotsFolder).toBe(
+        "/home/user/test/c8yscrn"
+      );
+      expect(options.config.e2e.trashAssetsBeforeRuns).toBe(false);
+      expect(options.config.e2e.specPattern.endsWith(".ts")).toBe(true);
+      expect(options.configFile.endsWith(".ts")).toBe(true);
+    });
+
+    it("should return custom options", () => {
+      const options = resolveConfigOptions({
+        browser: "firefox",
+        clear: true,
+        folder: "my/c8yscrn/folder",
+        tags: ["tag1", "tag2"],
+        baseUrl: "http://localhost:4200",
+      });
+      expect(options.browser).toBe("firefox");
+      expect(options.quiet).toBe(true);
+      expect(options.testingType).toBe("e2e");
+      expect(options.config.e2e.baseUrl).toBe("http://localhost:4200");
+      expect(options.config.e2e.screenshotsFolder).toBe(
+        "/home/user/test/my/c8yscrn/folder"
+      );
+      expect(options.config.e2e.trashAssetsBeforeRuns).toBe(true);
+      expect(options.config.e2e.specPattern.endsWith(".ts")).toBe(true);
+      expect(options.configFile.endsWith(".ts")).toBe(true);
+    });
+  });
+
+  describe("resolveBaseUrl", () => {
+    const originalEnv = process.env;
+    beforeAll(() => {
+      process.env = {
+        ...originalEnv,
+        C8Y_BASEURL: "http://localhost:4200",
+      };
+    });
+    afterAll(() => {
+      process.env = originalEnv;
+    });
+    
+    it("should return custom base url", () => {
+      expect(
+        resolveConfigOptions({ baseUrl: "http://localhost:4200" }).config.e2e
+          .baseUrl
+      ).toBe("http://localhost:4200");
+    });
+
+    it("should return base url from env", () => {
+      expect(resolveConfigOptions({}).config.e2e.baseUrl).toBe(
+        "http://localhost:4200"
+      );
     });
   });
 });

--- a/src/screenshot/helper.ts
+++ b/src/screenshot/helper.ts
@@ -1,5 +1,8 @@
 import * as yaml from "yaml";
 import * as fs from "fs";
+import * as path from "path";
+
+import { C8yScreenshotOptions } from "cumulocity-cypress/lib/screenshots/types";
 
 export function readYamlFile(filePath: string): any {
   const fileContent = fs.readFileSync(filePath, "utf-8");
@@ -29,4 +32,72 @@ screenshots:
     tags:
       - cockpit
 `;
+}
+
+export function resolveScreenshotFolder(
+  args: Partial<C8yScreenshotOptions>
+): string {
+  const screenshotsFolder = path.resolve(
+    process.cwd(),
+    args.folder ?? "c8yscrn"
+  );
+  if (screenshotsFolder == process.cwd()) {
+    throw new Error(
+      `Please provide a screenshot folder path that does not resolve to the current working directory.`
+    );
+  }
+
+  return screenshotsFolder;
+}
+
+export function resolveConfigOptions(args: Partial<C8yScreenshotOptions>): any {
+  const browser = (args.browser ?? process.env.C8Y_BROWSER ?? "chrome")
+    .toLowerCase()
+    .trim();
+  if (!["chrome", "firefox", "electron"].includes(browser)) {
+    throw new Error(
+      `Invalid browser ${browser}. Supported browsers are chrome, firefox, electron.`
+    );
+  }
+
+  // might run in different environments, so we need to find the correct extension
+  // this is required when running in development mode from ts files
+  const fileExtension = resolveFileExtension();
+  const cypressConfigFile = path.resolve(
+    path.dirname(__filename),
+    `config.${fileExtension}`
+  );
+
+  const screenshotsFolder = resolveScreenshotFolder(args);
+  const baseUrl = resolveBaseUrl(args);
+
+  return {
+    configFile: cypressConfigFile,
+    browser,
+    testingType: "e2e" as const,
+    quiet: args.quiet ?? true,
+    config: {
+      e2e: {
+        baseUrl,
+        screenshotsFolder,
+        trashAssetsBeforeRuns: args.clear ?? false,
+        specPattern: path.join(
+          path.dirname(__filename),
+          `*.cy.${fileExtension}`
+        ),
+      },
+    },
+  };
+}
+
+export function resolveFileExtension(): string {
+  let fileExtension = __filename?.split(".")?.pop();
+  if (!fileExtension || !["js", "ts", "mjs", "cjs"].includes(fileExtension)) {
+    fileExtension = "js";
+  }
+  return fileExtension;
+}
+
+export function resolveBaseUrl(args: Partial<C8yScreenshotOptions>): string {
+  return args.baseUrl ?? process.env.C8Y_BASEURL ?? "http://localhost:8080";
 }

--- a/src/screenshot/runner.ts
+++ b/src/screenshot/runner.ts
@@ -69,7 +69,7 @@ export class C8yScreenshotRunner {
         _.isNil
       ),
       {
-        overwrite: true,
+        overwrite: false,
         scale: false,
         disableTimersAndAnimations: true,
       }
@@ -195,6 +195,8 @@ export class C8yScreenshotRunner {
               !lastAction ||
               !isScreenshotAction(lastAction)
             ) {
+              cy.task("debug", `Taking screenshot ${item.image}`);
+              cy.task("debug", `Options: ${JSON.stringify(options)}`);
               cy.screenshot(item.image, options);
             }
           },

--- a/src/shared/c8ypact/fileadapter.ts
+++ b/src/shared/c8ypact/fileadapter.ts
@@ -38,7 +38,7 @@ export interface C8yPactFileAdapter {
   getFolder: () => string;
 }
 
-const log = debug("c8y:plugin:fileadapter");
+const log = debug("c8y:fileadapter");
 
 /**
  * Default implementation of C8yPactFileAdapter which loads and saves pact objects from/to


### PR DESCRIPTION
The screenshot folder was cleared before every run of `c8yscrn`. To clear the screenshot folder, use the `--clear` command line option when running `c8yscrn` to avoid unintented data loss. The `global.overwrite` setting in the workflow file is now considered for `run`.  If disabled, existing screenshots are not overwritten.