### PR TITLE
fix(c8yscrn): Fix using baseUrl from config file

### DIFF
--- a/src/screenshot/helper.spec.ts
+++ b/src/screenshot/helper.spec.ts
@@ -83,7 +83,7 @@ describe("startup", () => {
       expect(options.browser).toBe("chrome");
       expect(options.quiet).toBe(true);
       expect(options.testingType).toBe("e2e");
-      expect(options.config.e2e.baseUrl).toBe("http://localhost:8080");
+      expect(options.config.e2e.baseUrl).toBe(undefined);
       expect(options.config.e2e.screenshotsFolder).toBe(
         "/home/user/test/c8yscrn"
       );

--- a/src/screenshot/helper.ts
+++ b/src/screenshot/helper.ts
@@ -99,6 +99,6 @@ export function resolveFileExtension(): string {
   return fileExtension;
 }
 
-export function resolveBaseUrl(args: Partial<C8yScreenshotOptions>): string {
-  return args.baseUrl ?? process.env.C8Y_BASEURL ?? "http://localhost:8080";
+export function resolveBaseUrl(args: Partial<C8yScreenshotOptions>): string | undefined{
+  return args.baseUrl ?? process.env.C8Y_BASEURL;
 }

--- a/src/screenshot/startup.ts
+++ b/src/screenshot/startup.ts
@@ -13,6 +13,7 @@ import schema from "./../screenshot/schema.json";
 import {
   createInitConfig,
   readYamlFile,
+  resolveBaseUrl,
   resolveConfigOptions,
   resolveFileExtension,
 } from "./helper";
@@ -33,12 +34,16 @@ const log = debug("c8y:scrn:startup");
       );
     }
     const resolvedCypressConfig = resolveConfigOptions(args);
-    const baseUrl = resolvedCypressConfig.config.e2e.baseUrl;
+    let baseUrl = resolveBaseUrl(args);
 
     const yamlFile = path.resolve(process.cwd(), args.config);
     if (args.init === true) {
       if (!fs.existsSync(yamlFile)) {
-        fs.writeFileSync(yamlFile, createInitConfig(baseUrl), "utf8");
+        fs.writeFileSync(
+          yamlFile,
+          createInitConfig(baseUrl ?? "http://localhost:8080"),
+          "utf8"
+        );
         log(`Config file ${yamlFile} created.`);
       } else {
         throw new Error(`Config file ${yamlFile} already exists.`);
@@ -73,6 +78,8 @@ const log = debug("c8y:scrn:startup");
       throw new Error(`Invalid config file. ${error.message}`);
     }
 
+    baseUrl = baseUrl ?? configData.baseUrl ?? "http://localhost:8080";
+    resolvedCypressConfig.config.e2e.baseUrl = baseUrl;
     log(`Using baseUrl ${baseUrl}`);
 
     const screenshotsFolder =


### PR DESCRIPTION
The `baseUrl` configured in the config file was ignored. It is now used if not overwritten using `baseUrl` command line option or `C8Y_BASEURL` env variable.