### PR TITLE
fix(c8yscrn): Use new default wait selector for visit

### DIFF
--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -60,6 +60,12 @@ export type GlobalVisitOptions = {
    * @examples ["2024-09-26T19:17:35+02:00"]
    */
   date?: string;
+  /**
+   * The selector to wait for when visiting a page
+   * @default "c8y-drawer-outlet c8y-app-icon .c8y-icon"
+   * @examples ["c8y-drawer-outlet c8y-app-icon .c8y-icon"]
+   */
+  visitWaitSelector?: string;
 };
 
 export type Screenshot = GlobalVisitOptions &
@@ -70,7 +76,7 @@ export type Screenshot = GlobalVisitOptions &
      */
     image: string;
     /**
-     * The URI to visit
+     * The URI to visit. This typically a relative path to the baseUrl.
      * @examples ["/apps/cockpit/index.html#/"]
      */
     visit: string | Visit;
@@ -184,8 +190,7 @@ export type Visit = GlobalVisitOptions & {
   timeout?: number;
   /**
    * The selector to wait for before taking the screenshot.
-   * @examples ["c8y-navigator-outlet c8y-app-icon"]
-   * @default "c8y-navigator-outlet c8y-app-icon"
+   * @examples ["c8y-drawer-outlet c8y-app-icon .c8y-icon"]
    */
   selector?: string;
 };

--- a/src/screenshot/runner.ts
+++ b/src/screenshot/runner.ts
@@ -148,7 +148,11 @@ export class C8yScreenshotRunner {
             cy.login(visitUser);
 
             const url = visitObject?.url ?? (item.visit as string);
-            const visitSelector = visitObject?.selector;
+            const visitSelector =
+              visitObject?.selector ??
+              this.config.global?.visitWaitSelector ??
+              "c8y-drawer-outlet c8y-app-icon .c8y-icon";
+            cy.task("debug", `Visiting ${url} Selector: ${visitSelector}`);
             const visitTimeout = visitObject?.timeout;
 
             const language =

--- a/src/screenshot/schema.json
+++ b/src/screenshot/schema.json
@@ -718,10 +718,18 @@
                             "type": "string"
                         }
                     ],
-                    "description": "The URI to visit",
+                    "description": "The URI to visit. This typically a relative path to the baseUrl.",
                     "examples": [
                         "/apps/cockpit/index.html#/"
                     ]
+                },
+                "visitWaitSelector": {
+                    "default": "c8y-drawer-outlet c8y-app-icon .c8y-icon",
+                    "description": "The selector to wait for when visiting a page",
+                    "examples": [
+                        "c8y-drawer-outlet c8y-app-icon .c8y-icon"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
@@ -762,10 +770,9 @@
                     "type": "string"
                 },
                 "selector": {
-                    "default": "c8y-navigator-outlet c8y-app-icon",
                     "description": "The selector to wait for before taking the screenshot.",
                     "examples": [
-                        "c8y-navigator-outlet c8y-app-icon"
+                        "c8y-drawer-outlet c8y-app-icon .c8y-icon"
                     ],
                     "type": "string"
                 },
@@ -785,6 +792,14 @@
                     "description": "The login user alias. Configure *user*_username and *user*_password env\nvariables to set the actual user id and password.",
                     "examples": [
                         "admin"
+                    ],
+                    "type": "string"
+                },
+                "visitWaitSelector": {
+                    "default": "c8y-drawer-outlet c8y-app-icon .c8y-icon",
+                    "description": "The selector to wait for when visiting a page",
+                    "examples": [
+                        "c8y-drawer-outlet c8y-app-icon .c8y-icon"
                     ],
                     "type": "string"
                 }
@@ -913,6 +928,14 @@
                     "description": "The width in px to use for the browser window",
                     "minimum": 0,
                     "type": "integer"
+                },
+                "visitWaitSelector": {
+                    "default": "c8y-drawer-outlet c8y-app-icon .c8y-icon",
+                    "description": "The selector to wait for when visiting a page",
+                    "examples": [
+                        "c8y-drawer-outlet c8y-app-icon .c8y-icon"
+                    ],
+                    "type": "string"
                 }
             },
             "type": "object"


### PR DESCRIPTION
Visit wait selector is using new default that works with latest Cumulocity. Added support for overwriting visit selector globally with `global.visitWaitSelector`.  