### PR TITLE
fix(c8yscrn): Use data-cy outside of selectors

### DIFF
--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -201,108 +201,62 @@ export type Visit = GlobalVisitOptions & {
   selector?: string;
 };
 
-export type ClickAction = {
+export interface ClickAction extends Selector {
   /**
-   * A click action triggers a click event on the selected DOM element.
+   * If true, the click event is triggered on all matching elements. The default is false.
+   * @default false
    */
-  click?: {
-    /**
-     * The selector to click
-     */
-    selector: Selector;
-    /**
-     * If true, the click event is triggered on all matching elements. The default is false.
-     * @default false
-     */
-    multiple?: boolean;
-    /**
-     * If true, the click event is triggered even if the element is not visible. The default is false.
-     * @default false
-     */
-    force?: boolean;
-  };
-};
+  multiple?: boolean;
+  /**
+   * If true, the click event is triggered even if the element is not visible. The default is false.
+   * @default false
+   */
+  force?: boolean;
+}
 
-export type TypeAction = {
+export interface TypeAction extends Selector {
   /**
-   * A type action triggers a type event on the selected DOM element. Use to
-   * simulate typing in an input field.
+   * The value to type
    */
-  type?: {
-    /**
-     * The selector to type
-     */
-    selector: Selector;
-    /**
-     * The value to type
-     */
-    value: string;
-  };
-};
+  value: string;
+}
 
-export type TextAction = {
+export interface TextAction extends Selector {
   /**
-   * A text action modifies the text value of selected DOM element.
+   * The value to set
    */
-  text?: {
-    /*
-     * The selector to modify
-     */
-    selector: Selector;
-    /**
-     * The value to set
-     */
-    value: string;
-  };
-};
+  value: string;
+}
 
-export type WaitAction = {
+export interface WaitAction extends Selector {
   /**
-   * A wait action waits for the given time in ms or for a given
-   * chainer assertion.
-   * @examples [1000, 10000]
+   * The timeout in ms to wait for
+   * @TJS-type integer
+   * @default 4000
    */
-  wait?:
-    | number
+  timeout?: number;
+  /**
+   * The chainer assertion to wait for. This translates to a Cypress get().should().
+   * See https://docs.cypress.io/api/commands/should
+   */
+  assert?:
+    | string
     | {
         /**
-         * The selector of the DOM element to wait for
+         * The chainer assertion to. Could be any valid Cypress chainer. The chainer is
+         * not validated and may or may not have a value to assert.
+         * @examples ["have.length", "eq", "be.visible"]
          */
-        selector: Selector;
+        chainer: string;
         /**
-         * The timeout in ms to wait for
-         * @TJS-type integer
-         * @default 4000
+         * The value to assert. The value is optional and may not be required by the
+         * chainer assertion.
          */
-        timeout?: number;
-        /**
-         * The chainer assertion to wait for. This translates to a Cypress get().should().
-         * See https://docs.cypress.io/api/commands/should
-         */
-        assert?:
-          | string
-          | {
-              /**
-               * The chainer assertion to. Could be any valid Cypress chainer. The chainer is
-               * not validated and may or may not have a value to assert.
-               * @examples ["have.length", "eq", "be.visible"]
-               */
-              chainer: string;
-              /**
-               * The value to assert. The value is optional and may not be required by the
-               * chainer assertion.
-               */
-              value?: string | string[];
-            };
+        value?: string | string[];
       };
-};
+}
 
-export type UploadFileOptions = {
-  /**
-   * The selector of the DOM element to upload the file
-   * @examples [["input[type=file]", "[type$=\"file\"]"]]
-   */
-  selector?: Selector;
+export interface UploadFileAction extends Selector {
   /**
    * The path to the file to upload. Resolve the file path relative to the current working directory. Currently, only a single file of types .json, .txt, .csv, .png, .jpg, .jpeg, .gif can be uploaded. If file does not have required extension, overwrite extension in the fileName property.
    */
@@ -328,17 +282,9 @@ export type UploadFileOptions = {
    * @default false
    */
   force?: boolean;
-};
+}
 
-export type UploadFileAction = {
-  fileUpload?: string | UploadFileOptions;
-};
-
-export type HighlightActionProperties = {
-  /**
-   * The selector of the DOM element to highlight
-   */
-  selector: Selector;
+export interface HighlightAction extends Selector {
   /**
    * The border style. Use any valid CSS border style.
    * @examples ["1px solid red"]
@@ -349,16 +295,9 @@ export type HighlightActionProperties = {
    * @examples ["background-color: yellow", "outline: dashed", "outline-offset: +3px"]
    */
   styles?: any;
-};
+}
 
-export type HighlightAction = {
-  /**
-   * Use highlight action to visually highlight a selected DOM element in the screenshot. By default, the element is highlighted with an orange border. Use any valid CSS styles to highlight the element.
-   */
-  highlight?: HighlightActionProperties | HighlightActionProperties[] | string;
-};
-
-export type ScreenshotClipArea = {
+export interface ScreenshotClipArea {
   /**
    * The x-coordinate of the top-left corner of the clip area
    * @minimum 0
@@ -383,45 +322,63 @@ export type ScreenshotClipArea = {
    * @TJS-type integer
    */
   height: number;
-};
+}
 
-export type Selector =
-  | string
-  | {
-      "data-cy"?: string;
-    };
+export interface ScreenshotAction extends Selector {
+  /**
+   * The path to store the screenshot. This is the relative path used
+   * within the screenshot folder.
+   */
+  path?: string;
+  /**
+   * The clip area within the screenshot image. The clip area is defined
+   * by the top-left corner (x, y) and the width and height of the clip area.
+   */
+  clip?: ScreenshotClipArea;
+}
 
-export type ScreenshotAction = {
+export interface Action {
+  /**
+   * A click action triggers a click event on the selected DOM element.
+   */
+  click?: string | ClickAction;
+  /**
+   * Use the file upload action to upload a file using the file input element. Currently supported file types are .json, .txt, .csv, .png, .jpg, .jpeg, .gif.
+   */
+  fileUpload?: UploadFileAction | string;
+  /**
+   * Use highlight action to visually highlight a selected DOM element in the screenshot. By default, the element is highlighted with an orange border. Use any valid CSS styles to highlight the element.
+   */
+  highlight?: HighlightAction | HighlightAction[] | string;
   /**
    * The screenshot action triggers a screenshot of the current state of the
    * application.
    */
-  screenshot?: {
-    /**
-     * The path to store the screenshot. This is the relative path used
-     * within the screenshot folder.
-     */
-    path?: string;
-    /**
-     * The clip area within the screenshot image. The clip area is defined
-     * by the top-left corner (x, y) and the width and height of the clip area.
-     */
-    clip?: ScreenshotClipArea;
-    /**
-     * The selector of the DOM element to capture
-     */
-    selector?: Selector;
-  };
-};
+  screenshot?: ScreenshotAction;
+  /**
+   * A text action modifies the text value of selected DOM element.
+   */
+  text?: TextAction;
+  /**
+   * A type action triggers a type event on the selected DOM element. Use to
+   * simulate typing in an input field.
+   */
+  type?: TypeAction;
+  /**
+   * A wait action waits for the given time in ms or for a given
+   * chainer assertion.
+   * @examples [1000, 10000]
+   */
+  wait?: number | WaitAction;
+}
 
-export type Action =
-  | ClickAction
-  | TypeAction
-  | ScreenshotAction
-  | HighlightAction
-  | TextAction
-  | WaitAction
-  | UploadFileAction;
+export interface DataCySelector {
+  "data-cy"?: string;
+}
+
+export interface Selector extends DataCySelector {
+  selector?: string | DataCySelector;
+}
 
 // Internal types used within C8yScreenshotRunner
 // This will not be exposed to schema.json

--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -201,7 +201,7 @@ export type Visit = GlobalVisitOptions & {
   selector?: string;
 };
 
-export interface ClickAction extends Selector {
+export interface ClickAction {
   /**
    * If true, the click event is triggered on all matching elements. The default is false.
    * @default false
@@ -214,21 +214,21 @@ export interface ClickAction extends Selector {
   force?: boolean;
 }
 
-export interface TypeAction extends Selector {
+export interface TypeAction {
   /**
    * The value to type
    */
   value: string;
 }
 
-export interface TextAction extends Selector {
+export interface TextAction {
   /**
    * The value to set
    */
   value: string;
 }
 
-export interface WaitAction extends Selector {
+export interface WaitAction {
   /**
    * The timeout in ms to wait for
    * @TJS-type integer
@@ -256,7 +256,7 @@ export interface WaitAction extends Selector {
       };
 }
 
-export interface UploadFileAction extends Selector {
+export interface UploadFileAction {
   /**
    * The path to the file to upload. Resolve the file path relative to the current working directory. Currently, only a single file of types .json, .txt, .csv, .png, .jpg, .jpeg, .gif can be uploaded. If file does not have required extension, overwrite extension in the fileName property.
    */
@@ -271,7 +271,6 @@ export interface UploadFileAction extends Selector {
    * @examples [["binary", "utf8"]]
    */
   encoding?: "binary" | "utf8" | "utf-8";
-
   /**
    * The type of the file input element. The default is 'input'.
    * @default "input"
@@ -284,7 +283,7 @@ export interface UploadFileAction extends Selector {
   force?: boolean;
 }
 
-export interface HighlightAction extends Selector {
+export interface HighlightAction {
   /**
    * The border style. Use any valid CSS border style.
    * @examples ["1px solid red"]
@@ -296,6 +295,8 @@ export interface HighlightAction extends Selector {
    */
   styles?: any;
 }
+
+export type SelectableHighlightAction = HighlightAction & Selectable
 
 export interface ScreenshotClipArea {
   /**
@@ -324,7 +325,7 @@ export interface ScreenshotClipArea {
   height: number;
 }
 
-export interface ScreenshotAction extends Selector {
+export interface ScreenshotAction {
   /**
    * The path to store the screenshot. This is the relative path used
    * within the screenshot folder.
@@ -341,29 +342,29 @@ export interface Action {
   /**
    * A click action triggers a click event on the selected DOM element.
    */
-  click?: string | ClickAction;
+  click?: string | ClickAction & Selectable;
   /**
    * Use the file upload action to upload a file using the file input element. Currently supported file types are .json, .txt, .csv, .png, .jpg, .jpeg, .gif.
    */
-  fileUpload?: UploadFileAction | string;
+  fileUpload?: string | UploadFileAction & Selectable;
   /**
    * Use highlight action to visually highlight a selected DOM element in the screenshot. By default, the element is highlighted with an orange border. Use any valid CSS styles to highlight the element.
    */
-  highlight?: HighlightAction | HighlightAction[] | string;
+  highlight?: string | SelectableHighlightAction | SelectableHighlightAction[];
   /**
    * The screenshot action triggers a screenshot of the current state of the
    * application.
    */
-  screenshot?: ScreenshotAction;
+  screenshot?: ScreenshotAction & Partial<Selectable>;
   /**
    * A text action modifies the text value of selected DOM element.
    */
-  text?: TextAction;
+  text?: TextAction & Selectable;
   /**
    * A type action triggers a type event on the selected DOM element. Use to
    * simulate typing in an input field.
    */
-  type?: TypeAction;
+  type?: TypeAction & Selectable;
   /**
    * A wait action waits for the given time in ms or for a given
    * chainer assertion.
@@ -372,13 +373,15 @@ export interface Action {
   wait?: number | WaitAction;
 }
 
-export interface DataCySelector {
-  "data-cy"?: string;
+export type DataCySelector = {
+  "data-cy": string;
 }
 
-export interface Selector extends DataCySelector {
-  selector?: string | DataCySelector;
+export type Selector = {
+  selector: string | DataCySelector;
 }
+
+export type Selectable = Selector | DataCySelector;
 
 // Internal types used within C8yScreenshotRunner
 // This will not be exposed to schema.json

--- a/src/screenshot/runner.ts
+++ b/src/screenshot/runner.ts
@@ -11,7 +11,6 @@ import {
   Screenshot,
   ScreenshotSetup,
   Selector,
-  UploadFileAction,
   Visit,
 } from "../lib/screenshots/types";
 
@@ -316,7 +315,7 @@ export class C8yScreenshotRunner {
 
   protected fileUpload(action: Action["fileUpload"]) {
     const defaultSelector = '[type$="file"]';
-    let fileUpload: UploadFileAction | undefined = undefined;
+    let fileUpload: Action["fileUpload"] = undefined;
     if (_.isString(action)) {
       fileUpload = { selector: defaultSelector, file: action };
     } else if (action != null) {

--- a/src/screenshot/runner.ts
+++ b/src/screenshot/runner.ts
@@ -8,18 +8,11 @@ import { pactId } from "../shared/c8ypact";
 import {
   Action,
   C8yScreenshotFileUploadOptions,
-  ClickAction,
-  HighlightAction,
   Screenshot,
-  ScreenshotAction,
   ScreenshotSetup,
   Selector,
-  TextAction,
-  TypeAction,
   UploadFileAction,
-  UploadFileOptions,
   Visit,
-  WaitAction,
 } from "../lib/screenshots/types";
 
 import { C8yAjvSchemaMatcher } from "../contrib/ajv";
@@ -189,7 +182,8 @@ export class C8yScreenshotRunner {
             let actions = item.actions == null ? [] : item.actions;
             actions = _.isArray(actions) ? actions : [actions];
             actions.forEach((action) => {
-              const handler = this.actionHandlers[Object.keys(action)[0]];
+              const handlerKey = Object.keys(action)[0];
+              const handler = this.actionHandlers[handlerKey];
               if (handler) {
                 if (isScreenshotAction(action)) {
                   const clipArea = action.screenshot?.clip;
@@ -208,7 +202,7 @@ export class C8yScreenshotRunner {
                     };
                   }
                 }
-                handler(action, this, item, options);
+                handler(_.get(action, handlerKey), this, item, options);
               }
             });
 
@@ -229,30 +223,31 @@ export class C8yScreenshotRunner {
     });
   }
 
-  protected click(action: ClickAction) {
-    const selector = getSelector(action.click?.selector);
+
+  protected click(action: Action["click"]) {
+    const click = _.isString(action) ? { selector: action } : action;
+    const selector = getSelector(click);
     if (selector == null) return;
 
-    const multiple = action.click?.multiple ?? false;
-    const force = action.click?.force ?? false;
+    const multiple = click?.multiple ?? false;
+    const force = click?.force ?? false;
     cy.get(selector).click(_.omitBy({ multiple, force }, (v) => v === false));
   }
 
-  protected type(action: TypeAction) {
-    const selector = getSelector(action.type?.selector);
-    if (selector == null || action.type == null) return;
-    cy.get(selector).type(action.type.value);
+  protected type(action: Action["type"]) {
+    const selector = getSelector(action);
+    if (selector == null || action == null) return;
+    cy.get(selector).type(action.value);
   }
 
-  protected highlight(action: HighlightAction, that: C8yScreenshotRunner) {
-    const highlights = _.isArray(action.highlight)
-      ? action.highlight
-      : [action.highlight];
+  protected highlight(
+    action: Action["highlight"],
+    that: C8yScreenshotRunner
+  ) {
+    const highlights = _.isArray(action) ? action : [action];
 
     highlights?.forEach((highlight) => {
-      const selector = getSelector(
-        _.isString(highlight) ? highlight : highlight?.selector
-      );
+      const selector = getSelector(highlight);
       if (selector == null) return;
 
       cy.get(selector).then(($element) => {
@@ -279,24 +274,24 @@ export class C8yScreenshotRunner {
     });
   }
 
-  protected text(action: TextAction) {
-    const selector = getSelector(action.text?.selector);
-    const value = action.text?.value;
+  protected text(action: Action["text"]) {
+    const selector = getSelector(action);
+    const value = action?.value;
     if (selector == null || value == null) return;
     cy.get(selector).then(($element) => {
       $element.text(value);
     });
   }
 
-  protected wait(action: WaitAction) {
-    if (action.wait == null) return;
-    if (_.isNumber(action.wait)) {
-      cy.wait(action.wait);
-    } else if (_.isObjectLike(action.wait)) {
-      const selector = getSelector(action.wait.selector);
+  protected wait(action: Action["wait"]) {
+    if (action == null) return;
+    if (_.isNumber(action)) {
+      cy.wait(action);
+    } else if (_.isObjectLike(action)) {
+      const selector = getSelector(action);
       if (selector != null) {
-        const timeout = action.wait.timeout ?? 4000;
-        const chainer = action.wait.assert;
+        const timeout = action.timeout ?? 4000;
+        const chainer = action.assert;
         if (chainer != null) {
           if (_.isString(chainer)) {
             cy.get(selector, { timeout }).should(chainer);
@@ -319,16 +314,16 @@ export class C8yScreenshotRunner {
     }
   }
 
-  protected fileUpload(action: UploadFileAction) {
+  protected fileUpload(action: Action["fileUpload"]) {
     const defaultSelector = '[type$="file"]';
-    let fileUpload: UploadFileOptions | undefined = undefined;
-    if (_.isString(action.fileUpload)) {
-      fileUpload = { selector: defaultSelector, file: action.fileUpload };
-    } else if (action.fileUpload != null) {
-      fileUpload = action.fileUpload;
+    let fileUpload: UploadFileAction | undefined = undefined;
+    if (_.isString(action)) {
+      fileUpload = { selector: defaultSelector, file: action };
+    } else if (action != null) {
+      fileUpload = action;
     }
 
-    const selector = getSelector(fileUpload?.selector);
+    const selector = getSelector(fileUpload);
     const filePath = fileUpload?.file;
     if (selector == null || filePath == null) {
       cy.task("debug", `File upload selector or file path is missing`, taskLog);
@@ -338,58 +333,57 @@ export class C8yScreenshotRunner {
     cy.task<C8yScreenshotFileUploadOptions>("c8yscrn:file", {
       path: filePath,
       ..._.pick(fileUpload, ["encoding", "fileName"]),
-    })
-      .then((file) => {
-        if (file == null) {
-          cy.task("debug", `File ${filePath} not found`, taskLog);
-          return;
-        }
+    }).then((file) => {
+      if (file == null) {
+        cy.task("debug", `File ${filePath} not found`, taskLog);
+        return;
+      }
 
-        cy.task("debug", `Uploading file ${filePath} to ${selector}`, taskLog);
+      cy.task("debug", `Uploading file ${filePath} to ${selector}`, taskLog);
 
-        const attachData =
-          file.encoding === "binary"
-            ? Cypress.Blob.binaryStringToBlob(file.data)
-            : file.data;
-        const fixtureData = _.omitBy(
-          {
-            fileContent: attachData,
-            fileName: fileUpload?.fileName ?? file.filename,
-            ..._.pick(fileUpload, ["encoding", "lastModified"]),
-          },
-          _.isNil
-        );
-        const fileProcessingOptions = _.omitBy(
-          _.pick(action.fileUpload, ["subjectType", "force", "allowEmpty"]),
-          _.isNil
-        );
+      const attachData =
+        file.encoding === "binary"
+          ? Cypress.Blob.binaryStringToBlob(file.data)
+          : file.data;
+      const fixtureData = _.omitBy(
+        {
+          fileContent: attachData,
+          fileName: fileUpload?.fileName ?? file.filename,
+          ..._.pick(fileUpload, ["encoding", "lastModified"]),
+        },
+        _.isNil
+      );
+      const fileProcessingOptions = _.omitBy(
+        _.pick(fileUpload, ["subjectType", "force", "allowEmpty"]),
+        _.isNil
+      );
 
-        cy.task(
-          "debug",
-          `Fixture data: ${JSON.stringify({
-            ...fixtureData,
-            fileContent: "...",
-          })}`,
-          taskLog
-        );
-        cy.task(
-          "debug",
-          `File processing options: ${JSON.stringify(fileProcessingOptions)}`,
-          taskLog
-        );
+      cy.task(
+        "debug",
+        `Fixture data: ${JSON.stringify({
+          ...fixtureData,
+          fileContent: "...",
+        })}`,
+        taskLog
+      );
+      cy.task(
+        "debug",
+        `File processing options: ${JSON.stringify(fileProcessingOptions)}`,
+        taskLog
+      );
 
-        cy.get(selector).attachFile(fixtureData, fileProcessingOptions);
-      });
+      cy.get(selector).attachFile(fixtureData, fileProcessingOptions);
+    });
   }
 
   protected screenshot(
-    action: ScreenshotAction,
+    action: Action["screenshot"],
     _that: C8yScreenshotRunner,
     item: Screenshot,
     options: any
   ) {
-    let name = action.screenshot?.path || item.image;
-    const selector = getSelector(action.screenshot?.selector);
+    let name = action?.path || item.image;
+    const selector = getSelector(action);
     cy.task(
       "debug",
       `Taking screenshot ${name} Selector: ${selector}`,
@@ -437,34 +431,34 @@ export function isRecording(): boolean {
   return Cypress.env("C8Y_CTRL_MODE") === "recording";
 }
 
-export function isClickAction(action: Action): action is ClickAction {
+export function isClickAction(action: Action): boolean {
   return "click" in action;
 }
 
-export function isTypeAction(action: Action): action is TypeAction {
+export function isTypeAction(action: Action): boolean {
   return "type" in action;
 }
 
-export function isHighlightAction(action: Action): action is HighlightAction {
+export function isHighlightAction(action: Action): boolean {
   return "highlight" in action;
 }
 
-export function isScreenshotAction(action: Action): action is ScreenshotAction {
+export function isScreenshotAction(action: Action): boolean {
   return "screenshot" in action;
 }
 
 export function getSelector(
-  selector: Selector | undefined
+  selector: any | string | undefined
 ): string | undefined {
-  if (!selector) {
-    return undefined;
-  }
-  if (_.isString(selector)) {
-    return selector;
-  }
+  if (!selector) return undefined;
+  if (_.isString(selector)) return selector;
+
   if (_.isPlainObject(selector)) {
     if ("data-cy" in selector) {
       return `[data-cy=${_.get(selector, "data-cy")}]`;
+    }
+    if ("selector" in selector) {
+      return getSelector(selector.selector as Selector);
     }
   }
   return undefined;

--- a/src/screenshot/schema.json
+++ b/src/screenshot/schema.json
@@ -3,386 +3,148 @@
     "additionalProperties": false,
     "definitions": {
         "Action": {
-            "anyOf": [
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "click": {
-                            "additionalProperties": false,
-                            "description": "A click action triggers a click event on the selected DOM element.",
-                            "properties": {
-                                "force": {
-                                    "default": false,
-                                    "description": "If true, the click event is triggered even if the element is not visible. The default is false.",
-                                    "type": "boolean"
-                                },
-                                "multiple": {
-                                    "default": false,
-                                    "description": "If true, the click event is triggered on all matching elements. The default is false.",
-                                    "type": "boolean"
-                                },
-                                "selector": {
-                                    "$ref": "#/definitions/Selector",
-                                    "description": "The selector to click"
-                                }
+            "additionalProperties": false,
+            "properties": {
+                "click": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ClickAction"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "A click action triggers a click event on the selected DOM element."
+                },
+                "fileUpload": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/UploadFileAction"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Use the file upload action to upload a file using the file input element. Currently supported file types are .json, .txt, .csv, .png, .jpg, .jpeg, .gif."
+                },
+                "highlight": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/HighlightAction"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/definitions/HighlightAction"
                             },
-                            "required": [
-                                "selector"
-                            ],
-                            "type": "object"
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
                         }
-                    },
-                    "type": "object"
+                    ],
+                    "description": "Use highlight action to visually highlight a selected DOM element in the screenshot. By default, the element is highlighted with an orange border. Use any valid CSS styles to highlight the element."
                 },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "type": {
-                            "additionalProperties": false,
-                            "description": "A type action triggers a type event on the selected DOM element. Use to\nsimulate typing in an input field.",
-                            "properties": {
-                                "selector": {
-                                    "$ref": "#/definitions/Selector",
-                                    "description": "The selector to type"
-                                },
-                                "value": {
-                                    "description": "The value to type",
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "selector",
-                                "value"
-                            ],
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
+                "screenshot": {
+                    "$ref": "#/definitions/ScreenshotAction",
+                    "description": "The screenshot action triggers a screenshot of the current state of the\napplication."
                 },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "screenshot": {
-                            "additionalProperties": false,
-                            "description": "The screenshot action triggers a screenshot of the current state of the\napplication.",
-                            "properties": {
-                                "clip": {
-                                    "additionalProperties": false,
-                                    "description": "The clip area within the screenshot image. The clip area is defined\nby the top-left corner (x, y) and the width and height of the clip area.",
-                                    "properties": {
-                                        "height": {
-                                            "description": "The height of the clip area. If negative, the height is subtracted from the\nviewport height.",
-                                            "type": "integer"
-                                        },
-                                        "width": {
-                                            "description": "The width of the clip area. If negative, the width is subtracted from the\nviewport width.",
-                                            "type": "integer"
-                                        },
-                                        "x": {
-                                            "description": "The x-coordinate of the top-left corner of the clip area",
-                                            "minimum": 0,
-                                            "type": "integer"
-                                        },
-                                        "y": {
-                                            "description": "The y-coordinate of the top-left corner of the clip area",
-                                            "minimum": 0,
-                                            "type": "integer"
-                                        }
-                                    },
-                                    "required": [
-                                        "height",
-                                        "width",
-                                        "x",
-                                        "y"
-                                    ],
-                                    "type": "object"
-                                },
-                                "path": {
-                                    "description": "The path to store the screenshot. This is the relative path used\nwithin the screenshot folder.",
-                                    "type": "string"
-                                },
-                                "selector": {
-                                    "anyOf": [
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "data-cy": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        {
-                                            "type": "string"
-                                        }
-                                    ],
-                                    "description": "The selector of the DOM element to capture"
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
+                "text": {
+                    "$ref": "#/definitions/TextAction",
+                    "description": "A text action modifies the text value of selected DOM element."
                 },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "highlight": {
-                            "anyOf": [
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "border": {
-                                            "description": "The border style. Use any valid CSS border style.",
-                                            "examples": [
-                                                "1px solid red"
-                                            ],
-                                            "type": "string"
-                                        },
-                                        "selector": {
-                                            "$ref": "#/definitions/Selector",
-                                            "description": "The selector of the DOM element to highlight"
-                                        },
-                                        "styles": {
-                                            "description": "The CSS styles to apply to the DOM element. Use any valid CSS styles.",
-                                            "examples": [
-                                                "background-color: yellow",
-                                                "outline: dashed",
-                                                "outline-offset: +3px"
-                                            ]
-                                        }
-                                    },
-                                    "required": [
-                                        "selector"
-                                    ],
-                                    "type": "object"
-                                },
-                                {
-                                    "items": {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "border": {
-                                                "description": "The border style. Use any valid CSS border style.",
-                                                "examples": [
-                                                    "1px solid red"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            "selector": {
-                                                "$ref": "#/definitions/Selector",
-                                                "description": "The selector of the DOM element to highlight"
-                                            },
-                                            "styles": {
-                                                "description": "The CSS styles to apply to the DOM element. Use any valid CSS styles.",
-                                                "examples": [
-                                                    "background-color: yellow",
-                                                    "outline: dashed",
-                                                    "outline-offset: +3px"
-                                                ]
-                                            }
-                                        },
-                                        "required": [
-                                            "selector"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ],
-                            "description": "Use highlight action to visually highlight a selected DOM element in the screenshot. By default, the element is highlighted with an orange border. Use any valid CSS styles to highlight the element."
-                        }
-                    },
-                    "type": "object"
+                "type": {
+                    "$ref": "#/definitions/TypeAction",
+                    "description": "A type action triggers a type event on the selected DOM element. Use to\nsimulate typing in an input field."
                 },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "text": {
-                            "additionalProperties": false,
-                            "description": "A text action modifies the text value of selected DOM element.",
-                            "properties": {
-                                "selector": {
-                                    "$ref": "#/definitions/Selector"
-                                },
-                                "value": {
-                                    "description": "The value to set",
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "selector",
-                                "value"
-                            ],
-                            "type": "object"
+                "wait": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/WaitAction"
+                        },
+                        {
+                            "type": "number"
                         }
-                    },
-                    "type": "object"
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "wait": {
-                            "anyOf": [
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "assert": {
-                                            "anyOf": [
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "chainer": {
-                                                            "description": "The chainer assertion to. Could be any valid Cypress chainer. The chainer is\nnot validated and may or may not have a value to assert.",
-                                                            "examples": [
-                                                                "have.length",
-                                                                "eq",
-                                                                "be.visible"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        "value": {
-                                                            "anyOf": [
-                                                                {
-                                                                    "items": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "type": "array"
-                                                                },
-                                                                {
-                                                                    "type": "string"
-                                                                }
-                                                            ],
-                                                            "description": "The value to assert. The value is optional and may not be required by the\nchainer assertion."
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "chainer"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "type": "string"
-                                                }
-                                            ],
-                                            "description": "The chainer assertion to wait for. This translates to a Cypress get().should().\nSee https://docs.cypress.io/api/commands/should"
-                                        },
-                                        "selector": {
-                                            "$ref": "#/definitions/Selector",
-                                            "description": "The selector of the DOM element to wait for"
-                                        },
-                                        "timeout": {
-                                            "default": 4000,
-                                            "description": "The timeout in ms to wait for",
-                                            "type": "integer"
-                                        }
-                                    },
-                                    "required": [
-                                        "selector"
-                                    ],
-                                    "type": "object"
-                                },
-                                {
-                                    "type": "number"
-                                }
-                            ],
-                            "description": "A wait action waits for the given time in ms or for a given\nchainer assertion.",
-                            "examples": [
-                                1000,
-                                10000
-                            ]
-                        }
-                    },
-                    "type": "object"
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "fileUpload": {
-                            "anyOf": [
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "encoding": {
-                                            "description": "The encoding of the file. If not provided, the encoding is determined automatically. Default is 'utf8' or 'binary' depending of file extension.",
-                                            "enum": [
-                                                "binary",
-                                                "utf-8",
-                                                "utf8"
-                                            ],
-                                            "examples": [
-                                                [
-                                                    "binary",
-                                                    "utf8"
-                                                ]
-                                            ],
-                                            "type": "string"
-                                        },
-                                        "file": {
-                                            "description": "The path to the file to upload. Resolve the file path relative to the current working directory. Currently, only a single file of types .json, .txt, .csv, .png, .jpg, .jpeg, .gif can be uploaded. If file does not have required extension, overwrite extension in the fileName property.",
-                                            "type": "string"
-                                        },
-                                        "fileName": {
-                                            "description": "The name of the file to use when uploading including file extension. If not provided, the file name is determined from the file path.",
-                                            "examples": [
-                                                "file.txt"
-                                            ],
-                                            "type": "string"
-                                        },
-                                        "force": {
-                                            "default": false,
-                                            "description": "If true, the file is uploaded even if the element is not visible. The default is false.",
-                                            "type": "boolean"
-                                        },
-                                        "selector": {
-                                            "anyOf": [
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "data-cy": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "type": "string"
-                                                }
-                                            ],
-                                            "description": "The selector of the DOM element to upload the file",
-                                            "examples": [
-                                                [
-                                                    "input[type=file]",
-                                                    "[type$=\"file\"]"
-                                                ]
-                                            ]
-                                        },
-                                        "subjectType": {
-                                            "default": "input",
-                                            "description": "The type of the file input element. The default is 'input'.",
-                                            "enum": [
-                                                "drag-n-drop",
-                                                "input"
-                                            ],
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "file"
-                                    ],
-                                    "type": "object"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        }
-                    },
-                    "type": "object"
+                    ],
+                    "description": "A wait action waits for the given time in ms or for a given\nchainer assertion.",
+                    "examples": [
+                        1000,
+                        10000
+                    ]
                 }
-            ]
+            },
+            "type": "object"
+        },
+        "ClickAction": {
+            "additionalProperties": false,
+            "properties": {
+                "data-cy": {
+                    "type": "string"
+                },
+                "force": {
+                    "default": false,
+                    "description": "If true, the click event is triggered even if the element is not visible. The default is false.",
+                    "type": "boolean"
+                },
+                "multiple": {
+                    "default": false,
+                    "description": "If true, the click event is triggered on all matching elements. The default is false.",
+                    "type": "boolean"
+                },
+                "selector": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DataCySelector"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "DataCySelector": {
+            "additionalProperties": false,
+            "properties": {
+                "data-cy": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "HighlightAction": {
+            "additionalProperties": false,
+            "properties": {
+                "border": {
+                    "description": "The border style. Use any valid CSS border style.",
+                    "examples": [
+                        "1px solid red"
+                    ],
+                    "type": "string"
+                },
+                "data-cy": {
+                    "type": "string"
+                },
+                "selector": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DataCySelector"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "styles": {
+                    "description": "The CSS styles to apply to the DOM element. Use any valid CSS styles.",
+                    "examples": [
+                        "background-color: yellow",
+                        "outline: dashed",
+                        "outline-offset: +3px"
+                    ]
+                }
+            },
+            "type": "object"
         },
         "Screenshot": {
             "additionalProperties": false,
@@ -390,382 +152,7 @@
                 "actions": {
                     "anyOf": [
                         {
-                            "additionalProperties": false,
-                            "properties": {
-                                "click": {
-                                    "additionalProperties": false,
-                                    "description": "A click action triggers a click event on the selected DOM element.",
-                                    "properties": {
-                                        "force": {
-                                            "default": false,
-                                            "description": "If true, the click event is triggered even if the element is not visible. The default is false.",
-                                            "type": "boolean"
-                                        },
-                                        "multiple": {
-                                            "default": false,
-                                            "description": "If true, the click event is triggered on all matching elements. The default is false.",
-                                            "type": "boolean"
-                                        },
-                                        "selector": {
-                                            "$ref": "#/definitions/Selector",
-                                            "description": "The selector to click"
-                                        }
-                                    },
-                                    "required": [
-                                        "selector"
-                                    ],
-                                    "type": "object"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "additionalProperties": false,
-                            "properties": {
-                                "type": {
-                                    "additionalProperties": false,
-                                    "description": "A type action triggers a type event on the selected DOM element. Use to\nsimulate typing in an input field.",
-                                    "properties": {
-                                        "selector": {
-                                            "$ref": "#/definitions/Selector",
-                                            "description": "The selector to type"
-                                        },
-                                        "value": {
-                                            "description": "The value to type",
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "selector",
-                                        "value"
-                                    ],
-                                    "type": "object"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "additionalProperties": false,
-                            "properties": {
-                                "screenshot": {
-                                    "additionalProperties": false,
-                                    "description": "The screenshot action triggers a screenshot of the current state of the\napplication.",
-                                    "properties": {
-                                        "clip": {
-                                            "additionalProperties": false,
-                                            "description": "The clip area within the screenshot image. The clip area is defined\nby the top-left corner (x, y) and the width and height of the clip area.",
-                                            "properties": {
-                                                "height": {
-                                                    "description": "The height of the clip area. If negative, the height is subtracted from the\nviewport height.",
-                                                    "type": "integer"
-                                                },
-                                                "width": {
-                                                    "description": "The width of the clip area. If negative, the width is subtracted from the\nviewport width.",
-                                                    "type": "integer"
-                                                },
-                                                "x": {
-                                                    "description": "The x-coordinate of the top-left corner of the clip area",
-                                                    "minimum": 0,
-                                                    "type": "integer"
-                                                },
-                                                "y": {
-                                                    "description": "The y-coordinate of the top-left corner of the clip area",
-                                                    "minimum": 0,
-                                                    "type": "integer"
-                                                }
-                                            },
-                                            "required": [
-                                                "height",
-                                                "width",
-                                                "x",
-                                                "y"
-                                            ],
-                                            "type": "object"
-                                        },
-                                        "path": {
-                                            "description": "The path to store the screenshot. This is the relative path used\nwithin the screenshot folder.",
-                                            "type": "string"
-                                        },
-                                        "selector": {
-                                            "anyOf": [
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "data-cy": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "type": "string"
-                                                }
-                                            ],
-                                            "description": "The selector of the DOM element to capture"
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "additionalProperties": false,
-                            "properties": {
-                                "highlight": {
-                                    "anyOf": [
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "border": {
-                                                    "description": "The border style. Use any valid CSS border style.",
-                                                    "examples": [
-                                                        "1px solid red"
-                                                    ],
-                                                    "type": "string"
-                                                },
-                                                "selector": {
-                                                    "$ref": "#/definitions/Selector",
-                                                    "description": "The selector of the DOM element to highlight"
-                                                },
-                                                "styles": {
-                                                    "description": "The CSS styles to apply to the DOM element. Use any valid CSS styles.",
-                                                    "examples": [
-                                                        "background-color: yellow",
-                                                        "outline: dashed",
-                                                        "outline-offset: +3px"
-                                                    ]
-                                                }
-                                            },
-                                            "required": [
-                                                "selector"
-                                            ],
-                                            "type": "object"
-                                        },
-                                        {
-                                            "items": {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                    "border": {
-                                                        "description": "The border style. Use any valid CSS border style.",
-                                                        "examples": [
-                                                            "1px solid red"
-                                                        ],
-                                                        "type": "string"
-                                                    },
-                                                    "selector": {
-                                                        "$ref": "#/definitions/Selector",
-                                                        "description": "The selector of the DOM element to highlight"
-                                                    },
-                                                    "styles": {
-                                                        "description": "The CSS styles to apply to the DOM element. Use any valid CSS styles.",
-                                                        "examples": [
-                                                            "background-color: yellow",
-                                                            "outline: dashed",
-                                                            "outline-offset: +3px"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": [
-                                                    "selector"
-                                                ],
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": "string"
-                                        }
-                                    ],
-                                    "description": "Use highlight action to visually highlight a selected DOM element in the screenshot. By default, the element is highlighted with an orange border. Use any valid CSS styles to highlight the element."
-                                }
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "additionalProperties": false,
-                            "properties": {
-                                "text": {
-                                    "additionalProperties": false,
-                                    "description": "A text action modifies the text value of selected DOM element.",
-                                    "properties": {
-                                        "selector": {
-                                            "$ref": "#/definitions/Selector"
-                                        },
-                                        "value": {
-                                            "description": "The value to set",
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "selector",
-                                        "value"
-                                    ],
-                                    "type": "object"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "additionalProperties": false,
-                            "properties": {
-                                "wait": {
-                                    "anyOf": [
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "assert": {
-                                                    "anyOf": [
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "chainer": {
-                                                                    "description": "The chainer assertion to. Could be any valid Cypress chainer. The chainer is\nnot validated and may or may not have a value to assert.",
-                                                                    "examples": [
-                                                                        "have.length",
-                                                                        "eq",
-                                                                        "be.visible"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                "value": {
-                                                                    "anyOf": [
-                                                                        {
-                                                                            "items": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "type": "array"
-                                                                        },
-                                                                        {
-                                                                            "type": "string"
-                                                                        }
-                                                                    ],
-                                                                    "description": "The value to assert. The value is optional and may not be required by the\nchainer assertion."
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "chainer"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "type": "string"
-                                                        }
-                                                    ],
-                                                    "description": "The chainer assertion to wait for. This translates to a Cypress get().should().\nSee https://docs.cypress.io/api/commands/should"
-                                                },
-                                                "selector": {
-                                                    "$ref": "#/definitions/Selector",
-                                                    "description": "The selector of the DOM element to wait for"
-                                                },
-                                                "timeout": {
-                                                    "default": 4000,
-                                                    "description": "The timeout in ms to wait for",
-                                                    "type": "integer"
-                                                }
-                                            },
-                                            "required": [
-                                                "selector"
-                                            ],
-                                            "type": "object"
-                                        },
-                                        {
-                                            "type": "number"
-                                        }
-                                    ],
-                                    "description": "A wait action waits for the given time in ms or for a given\nchainer assertion.",
-                                    "examples": [
-                                        1000,
-                                        10000
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "additionalProperties": false,
-                            "properties": {
-                                "fileUpload": {
-                                    "anyOf": [
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "encoding": {
-                                                    "description": "The encoding of the file. If not provided, the encoding is determined automatically. Default is 'utf8' or 'binary' depending of file extension.",
-                                                    "enum": [
-                                                        "binary",
-                                                        "utf-8",
-                                                        "utf8"
-                                                    ],
-                                                    "examples": [
-                                                        [
-                                                            "binary",
-                                                            "utf8"
-                                                        ]
-                                                    ],
-                                                    "type": "string"
-                                                },
-                                                "file": {
-                                                    "description": "The path to the file to upload. Resolve the file path relative to the current working directory. Currently, only a single file of types .json, .txt, .csv, .png, .jpg, .jpeg, .gif can be uploaded. If file does not have required extension, overwrite extension in the fileName property.",
-                                                    "type": "string"
-                                                },
-                                                "fileName": {
-                                                    "description": "The name of the file to use when uploading including file extension. If not provided, the file name is determined from the file path.",
-                                                    "examples": [
-                                                        "file.txt"
-                                                    ],
-                                                    "type": "string"
-                                                },
-                                                "force": {
-                                                    "default": false,
-                                                    "description": "If true, the file is uploaded even if the element is not visible. The default is false.",
-                                                    "type": "boolean"
-                                                },
-                                                "selector": {
-                                                    "anyOf": [
-                                                        {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "data-cy": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "type": "object"
-                                                        },
-                                                        {
-                                                            "type": "string"
-                                                        }
-                                                    ],
-                                                    "description": "The selector of the DOM element to upload the file",
-                                                    "examples": [
-                                                        [
-                                                            "input[type=file]",
-                                                            "[type$=\"file\"]"
-                                                        ]
-                                                    ]
-                                                },
-                                                "subjectType": {
-                                                    "default": "input",
-                                                    "description": "The type of the file input element. The default is 'input'.",
-                                                    "enum": [
-                                                        "drag-n-drop",
-                                                        "input"
-                                                    ],
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "file"
-                                            ],
-                                            "type": "object"
-                                        },
-                                        {
-                                            "type": "string"
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
+                            "$ref": "#/definitions/Action"
                         },
                         {
                             "items": {
@@ -957,21 +344,176 @@
             ],
             "type": "object"
         },
-        "Selector": {
-            "anyOf": [
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "data-cy": {
+        "ScreenshotAction": {
+            "additionalProperties": false,
+            "properties": {
+                "clip": {
+                    "$ref": "#/definitions/ScreenshotClipArea",
+                    "description": "The clip area within the screenshot image. The clip area is defined\nby the top-left corner (x, y) and the width and height of the clip area."
+                },
+                "data-cy": {
+                    "type": "string"
+                },
+                "path": {
+                    "description": "The path to store the screenshot. This is the relative path used\nwithin the screenshot folder.",
+                    "type": "string"
+                },
+                "selector": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DataCySelector"
+                        },
+                        {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ScreenshotClipArea": {
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "description": "The height of the clip area. If negative, the height is subtracted from the\nviewport height.",
+                    "type": "integer"
                 },
-                {
+                "width": {
+                    "description": "The width of the clip area. If negative, the width is subtracted from the\nviewport width.",
+                    "type": "integer"
+                },
+                "x": {
+                    "description": "The x-coordinate of the top-left corner of the clip area",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "y": {
+                    "description": "The y-coordinate of the top-left corner of the clip area",
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "height",
+                "width",
+                "x",
+                "y"
+            ],
+            "type": "object"
+        },
+        "TextAction": {
+            "additionalProperties": false,
+            "properties": {
+                "data-cy": {
+                    "type": "string"
+                },
+                "selector": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DataCySelector"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "value": {
+                    "description": "The value to set",
                     "type": "string"
                 }
-            ]
+            },
+            "required": [
+                "value"
+            ],
+            "type": "object"
+        },
+        "TypeAction": {
+            "additionalProperties": false,
+            "properties": {
+                "data-cy": {
+                    "type": "string"
+                },
+                "selector": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DataCySelector"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "value": {
+                    "description": "The value to type",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "value"
+            ],
+            "type": "object"
+        },
+        "UploadFileAction": {
+            "additionalProperties": false,
+            "properties": {
+                "data-cy": {
+                    "type": "string"
+                },
+                "encoding": {
+                    "description": "The encoding of the file. If not provided, the encoding is determined automatically. Default is 'utf8' or 'binary' depending of file extension.",
+                    "enum": [
+                        "binary",
+                        "utf-8",
+                        "utf8"
+                    ],
+                    "examples": [
+                        [
+                            "binary",
+                            "utf8"
+                        ]
+                    ],
+                    "type": "string"
+                },
+                "file": {
+                    "description": "The path to the file to upload. Resolve the file path relative to the current working directory. Currently, only a single file of types .json, .txt, .csv, .png, .jpg, .jpeg, .gif can be uploaded. If file does not have required extension, overwrite extension in the fileName property.",
+                    "type": "string"
+                },
+                "fileName": {
+                    "description": "The name of the file to use when uploading including file extension. If not provided, the file name is determined from the file path.",
+                    "examples": [
+                        "file.txt"
+                    ],
+                    "type": "string"
+                },
+                "force": {
+                    "default": false,
+                    "description": "If true, the file is uploaded even if the element is not visible. The default is false.",
+                    "type": "boolean"
+                },
+                "selector": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DataCySelector"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "subjectType": {
+                    "default": "input",
+                    "description": "The type of the file input element. The default is 'input'.",
+                    "enum": [
+                        "drag-n-drop",
+                        "input"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "file"
+            ],
+            "type": "object"
         },
         "Visit": {
             "additionalProperties": false,
@@ -1040,6 +582,70 @@
             "required": [
                 "url"
             ],
+            "type": "object"
+        },
+        "WaitAction": {
+            "additionalProperties": false,
+            "properties": {
+                "assert": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "chainer": {
+                                    "description": "The chainer assertion to. Could be any valid Cypress chainer. The chainer is\nnot validated and may or may not have a value to assert.",
+                                    "examples": [
+                                        "have.length",
+                                        "eq",
+                                        "be.visible"
+                                    ],
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The value to assert. The value is optional and may not be required by the\nchainer assertion."
+                                }
+                            },
+                            "required": [
+                                "chainer"
+                            ],
+                            "type": "object"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "The chainer assertion to wait for. This translates to a Cypress get().should().\nSee https://docs.cypress.io/api/commands/should"
+                },
+                "data-cy": {
+                    "type": "string"
+                },
+                "selector": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DataCySelector"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "timeout": {
+                    "default": 4000,
+                    "description": "The timeout in ms to wait for",
+                    "type": "integer"
+                }
+            },
             "type": "object"
         }
     },

--- a/src/screenshot/schema.json
+++ b/src/screenshot/schema.json
@@ -8,7 +8,64 @@
                 "click": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ClickAction"
+                            "additionalProperties": false,
+                            "properties": {
+                                "force": {
+                                    "default": false,
+                                    "description": "If true, the click event is triggered even if the element is not visible. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "multiple": {
+                                    "default": false,
+                                    "description": "If true, the click event is triggered on all matching elements. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "selector": {
+                                    "anyOf": [
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "data-cy": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "data-cy"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "selector"
+                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "data-cy": {
+                                    "type": "string"
+                                },
+                                "force": {
+                                    "default": false,
+                                    "description": "If true, the click event is triggered even if the element is not visible. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "multiple": {
+                                    "default": false,
+                                    "description": "If true, the click event is triggered on all matching elements. The default is false.",
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": [
+                                "data-cy"
+                            ],
+                            "type": "object"
                         },
                         {
                             "type": "string"
@@ -19,7 +76,126 @@
                 "fileUpload": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/UploadFileAction"
+                            "additionalProperties": false,
+                            "properties": {
+                                "encoding": {
+                                    "description": "The encoding of the file. If not provided, the encoding is determined automatically. Default is 'utf8' or 'binary' depending of file extension.",
+                                    "enum": [
+                                        "binary",
+                                        "utf-8",
+                                        "utf8"
+                                    ],
+                                    "examples": [
+                                        [
+                                            "binary",
+                                            "utf8"
+                                        ]
+                                    ],
+                                    "type": "string"
+                                },
+                                "file": {
+                                    "description": "The path to the file to upload. Resolve the file path relative to the current working directory. Currently, only a single file of types .json, .txt, .csv, .png, .jpg, .jpeg, .gif can be uploaded. If file does not have required extension, overwrite extension in the fileName property.",
+                                    "type": "string"
+                                },
+                                "fileName": {
+                                    "description": "The name of the file to use when uploading including file extension. If not provided, the file name is determined from the file path.",
+                                    "examples": [
+                                        "file.txt"
+                                    ],
+                                    "type": "string"
+                                },
+                                "force": {
+                                    "default": false,
+                                    "description": "If true, the file is uploaded even if the element is not visible. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "selector": {
+                                    "anyOf": [
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "data-cy": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "data-cy"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "subjectType": {
+                                    "default": "input",
+                                    "description": "The type of the file input element. The default is 'input'.",
+                                    "enum": [
+                                        "drag-n-drop",
+                                        "input"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "file",
+                                "selector"
+                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "data-cy": {
+                                    "type": "string"
+                                },
+                                "encoding": {
+                                    "description": "The encoding of the file. If not provided, the encoding is determined automatically. Default is 'utf8' or 'binary' depending of file extension.",
+                                    "enum": [
+                                        "binary",
+                                        "utf-8",
+                                        "utf8"
+                                    ],
+                                    "examples": [
+                                        [
+                                            "binary",
+                                            "utf8"
+                                        ]
+                                    ],
+                                    "type": "string"
+                                },
+                                "file": {
+                                    "description": "The path to the file to upload. Resolve the file path relative to the current working directory. Currently, only a single file of types .json, .txt, .csv, .png, .jpg, .jpeg, .gif can be uploaded. If file does not have required extension, overwrite extension in the fileName property.",
+                                    "type": "string"
+                                },
+                                "fileName": {
+                                    "description": "The name of the file to use when uploading including file extension. If not provided, the file name is determined from the file path.",
+                                    "examples": [
+                                        "file.txt"
+                                    ],
+                                    "type": "string"
+                                },
+                                "force": {
+                                    "default": false,
+                                    "description": "If true, the file is uploaded even if the element is not visible. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "subjectType": {
+                                    "default": "input",
+                                    "description": "The type of the file input element. The default is 'input'.",
+                                    "enum": [
+                                        "drag-n-drop",
+                                        "input"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "data-cy",
+                                "file"
+                            ],
+                            "type": "object"
                         },
                         {
                             "type": "string"
@@ -30,11 +206,78 @@
                 "highlight": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/HighlightAction"
+                            "additionalProperties": false,
+                            "properties": {
+                                "border": {
+                                    "description": "The border style. Use any valid CSS border style.",
+                                    "examples": [
+                                        "1px solid red"
+                                    ],
+                                    "type": "string"
+                                },
+                                "selector": {
+                                    "anyOf": [
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "data-cy": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "data-cy"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "styles": {
+                                    "description": "The CSS styles to apply to the DOM element. Use any valid CSS styles.",
+                                    "examples": [
+                                        "background-color: yellow",
+                                        "outline: dashed",
+                                        "outline-offset: +3px"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "selector"
+                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "border": {
+                                    "description": "The border style. Use any valid CSS border style.",
+                                    "examples": [
+                                        "1px solid red"
+                                    ],
+                                    "type": "string"
+                                },
+                                "data-cy": {
+                                    "type": "string"
+                                },
+                                "styles": {
+                                    "description": "The CSS styles to apply to the DOM element. Use any valid CSS styles.",
+                                    "examples": [
+                                        "background-color: yellow",
+                                        "outline: dashed",
+                                        "outline-offset: +3px"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "data-cy"
+                            ],
+                            "type": "object"
                         },
                         {
                             "items": {
-                                "$ref": "#/definitions/HighlightAction"
+                                "$ref": "#/definitions/SelectableHighlightAction"
                             },
                             "type": "array"
                         },
@@ -45,15 +288,168 @@
                     "description": "Use highlight action to visually highlight a selected DOM element in the screenshot. By default, the element is highlighted with an orange border. Use any valid CSS styles to highlight the element."
                 },
                 "screenshot": {
-                    "$ref": "#/definitions/ScreenshotAction",
+                    "anyOf": [
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "clip": {
+                                    "$ref": "#/definitions/ScreenshotClipArea",
+                                    "description": "The clip area within the screenshot image. The clip area is defined\nby the top-left corner (x, y) and the width and height of the clip area."
+                                },
+                                "path": {
+                                    "description": "The path to store the screenshot. This is the relative path used\nwithin the screenshot folder.",
+                                    "type": "string"
+                                },
+                                "selector": {
+                                    "anyOf": [
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "data-cy": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "data-cy"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "clip": {
+                                    "$ref": "#/definitions/ScreenshotClipArea",
+                                    "description": "The clip area within the screenshot image. The clip area is defined\nby the top-left corner (x, y) and the width and height of the clip area."
+                                },
+                                "data-cy": {
+                                    "type": "string"
+                                },
+                                "path": {
+                                    "description": "The path to store the screenshot. This is the relative path used\nwithin the screenshot folder.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ],
                     "description": "The screenshot action triggers a screenshot of the current state of the\napplication."
                 },
                 "text": {
-                    "$ref": "#/definitions/TextAction",
+                    "anyOf": [
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "selector": {
+                                    "anyOf": [
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "data-cy": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "data-cy"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "value": {
+                                    "description": "The value to set",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "selector",
+                                "value"
+                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "data-cy": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "description": "The value to set",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "data-cy",
+                                "value"
+                            ],
+                            "type": "object"
+                        }
+                    ],
                     "description": "A text action modifies the text value of selected DOM element."
                 },
                 "type": {
-                    "$ref": "#/definitions/TypeAction",
+                    "anyOf": [
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "selector": {
+                                    "anyOf": [
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "data-cy": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "data-cy"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "value": {
+                                    "description": "The value to type",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "selector",
+                                "value"
+                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "data-cy": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "description": "The value to type",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "data-cy",
+                                "value"
+                            ],
+                            "type": "object"
+                        }
+                    ],
                     "description": "A type action triggers a type event on the selected DOM element. Use to\nsimulate typing in an input field."
                 },
                 "wait": {
@@ -69,78 +465,6 @@
                     "examples": [
                         1000,
                         10000
-                    ]
-                }
-            },
-            "type": "object"
-        },
-        "ClickAction": {
-            "additionalProperties": false,
-            "properties": {
-                "data-cy": {
-                    "type": "string"
-                },
-                "force": {
-                    "default": false,
-                    "description": "If true, the click event is triggered even if the element is not visible. The default is false.",
-                    "type": "boolean"
-                },
-                "multiple": {
-                    "default": false,
-                    "description": "If true, the click event is triggered on all matching elements. The default is false.",
-                    "type": "boolean"
-                },
-                "selector": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/DataCySelector"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                }
-            },
-            "type": "object"
-        },
-        "DataCySelector": {
-            "additionalProperties": false,
-            "properties": {
-                "data-cy": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "HighlightAction": {
-            "additionalProperties": false,
-            "properties": {
-                "border": {
-                    "description": "The border style. Use any valid CSS border style.",
-                    "examples": [
-                        "1px solid red"
-                    ],
-                    "type": "string"
-                },
-                "data-cy": {
-                    "type": "string"
-                },
-                "selector": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/DataCySelector"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                "styles": {
-                    "description": "The CSS styles to apply to the DOM element. Use any valid CSS styles.",
-                    "examples": [
-                        "background-color: yellow",
-                        "outline: dashed",
-                        "outline-offset: +3px"
                     ]
                 }
             },
@@ -344,33 +668,6 @@
             ],
             "type": "object"
         },
-        "ScreenshotAction": {
-            "additionalProperties": false,
-            "properties": {
-                "clip": {
-                    "$ref": "#/definitions/ScreenshotClipArea",
-                    "description": "The clip area within the screenshot image. The clip area is defined\nby the top-left corner (x, y) and the width and height of the clip area."
-                },
-                "data-cy": {
-                    "type": "string"
-                },
-                "path": {
-                    "description": "The path to store the screenshot. This is the relative path used\nwithin the screenshot folder.",
-                    "type": "string"
-                },
-                "selector": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/DataCySelector"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                }
-            },
-            "type": "object"
-        },
         "ScreenshotClipArea": {
             "additionalProperties": false,
             "properties": {
@@ -401,119 +698,79 @@
             ],
             "type": "object"
         },
-        "TextAction": {
-            "additionalProperties": false,
-            "properties": {
-                "data-cy": {
-                    "type": "string"
-                },
-                "selector": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/DataCySelector"
-                        },
-                        {
+        "SelectableHighlightAction": {
+            "anyOf": [
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "border": {
+                            "description": "The border style. Use any valid CSS border style.",
+                            "examples": [
+                                "1px solid red"
+                            ],
                             "type": "string"
-                        }
-                    ]
-                },
-                "value": {
-                    "description": "The value to set",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "value"
-            ],
-            "type": "object"
-        },
-        "TypeAction": {
-            "additionalProperties": false,
-            "properties": {
-                "data-cy": {
-                    "type": "string"
-                },
-                "selector": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/DataCySelector"
                         },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                "value": {
-                    "description": "The value to type",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "value"
-            ],
-            "type": "object"
-        },
-        "UploadFileAction": {
-            "additionalProperties": false,
-            "properties": {
-                "data-cy": {
-                    "type": "string"
-                },
-                "encoding": {
-                    "description": "The encoding of the file. If not provided, the encoding is determined automatically. Default is 'utf8' or 'binary' depending of file extension.",
-                    "enum": [
-                        "binary",
-                        "utf-8",
-                        "utf8"
-                    ],
-                    "examples": [
-                        [
-                            "binary",
-                            "utf8"
-                        ]
-                    ],
-                    "type": "string"
-                },
-                "file": {
-                    "description": "The path to the file to upload. Resolve the file path relative to the current working directory. Currently, only a single file of types .json, .txt, .csv, .png, .jpg, .jpeg, .gif can be uploaded. If file does not have required extension, overwrite extension in the fileName property.",
-                    "type": "string"
-                },
-                "fileName": {
-                    "description": "The name of the file to use when uploading including file extension. If not provided, the file name is determined from the file path.",
-                    "examples": [
-                        "file.txt"
-                    ],
-                    "type": "string"
-                },
-                "force": {
-                    "default": false,
-                    "description": "If true, the file is uploaded even if the element is not visible. The default is false.",
-                    "type": "boolean"
-                },
-                "selector": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/DataCySelector"
+                        "selector": {
+                            "anyOf": [
+                                {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "data-cy": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "data-cy"
+                                    ],
+                                    "type": "object"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
                         },
-                        {
-                            "type": "string"
+                        "styles": {
+                            "description": "The CSS styles to apply to the DOM element. Use any valid CSS styles.",
+                            "examples": [
+                                "background-color: yellow",
+                                "outline: dashed",
+                                "outline-offset: +3px"
+                            ]
                         }
-                    ]
-                },
-                "subjectType": {
-                    "default": "input",
-                    "description": "The type of the file input element. The default is 'input'.",
-                    "enum": [
-                        "drag-n-drop",
-                        "input"
+                    },
+                    "required": [
+                        "selector"
                     ],
-                    "type": "string"
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "border": {
+                            "description": "The border style. Use any valid CSS border style.",
+                            "examples": [
+                                "1px solid red"
+                            ],
+                            "type": "string"
+                        },
+                        "data-cy": {
+                            "type": "string"
+                        },
+                        "styles": {
+                            "description": "The CSS styles to apply to the DOM element. Use any valid CSS styles.",
+                            "examples": [
+                                "background-color: yellow",
+                                "outline: dashed",
+                                "outline-offset: +3px"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "data-cy"
+                    ],
+                    "type": "object"
                 }
-            },
-            "required": [
-                "file"
-            ],
-            "type": "object"
+            ]
         },
         "Visit": {
             "additionalProperties": false,
@@ -626,19 +883,6 @@
                         }
                     ],
                     "description": "The chainer assertion to wait for. This translates to a Cypress get().should().\nSee https://docs.cypress.io/api/commands/should"
-                },
-                "data-cy": {
-                    "type": "string"
-                },
-                "selector": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/DataCySelector"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
                 },
                 "timeout": {
                     "default": 4000,


### PR DESCRIPTION
It is now possible to use `data-cy` for an action without nesting in a `selector`.