### PR TITLE
fix(c8yscrn): User and login are now optional

### DIFF
--- a/doc/Screenshot Automation.md
+++ b/doc/Screenshot Automation.md
@@ -425,9 +425,9 @@ global:
 - **Description**: The language to use when loading the Cumulocity application. This can be useful for capturing screenshots in different locales. Default language is `en`.
 - **Example**: `"en"` or `"de"`
 
-**user**
+**login**
 - **Type**: string
-- **Description**: The login user alias. Configure `*user*_username` and `*user*_password` environment variables to set the actual user ID and password. See the [Authentication](#authentication) section for more details.
+- **Description**: The login user alias to use for logging into Cumulocity. Configure `*login*_username` and `*login*_password` environment variables to set the actual user ID and password. See the [Authentication](#authentication) section for more details.
 - **Example**: `"admin"`
 
 **shell**
@@ -704,7 +704,7 @@ screenshots:
 ```yaml
 global:
   language: en
-  user: admin
+  login: admin
   shell: "oee"
   requires: "1017"
   tags: 

--- a/src/screenshot/runner.ts
+++ b/src/screenshot/runner.ts
@@ -88,8 +88,6 @@ export class C8yScreenshotRunner {
           cy.getAuth(this.config.global?.user).getShellVersion(
             this.config.global?.shell
           );
-        } else {
-          cy.getShellVersion(this.config.global?.shell);
         }
       });
 
@@ -122,8 +120,15 @@ export class C8yScreenshotRunner {
           annotations,
           // @ts-expect-error
           () => {
-            const user = item.user ?? this.config.global?.user ?? "admin";
-            cy.getAuth(user).getTenantId();
+            const user =
+              item.login ??
+              this.config.global?.login ??
+              item.user ??
+              this.config.global?.user;
+
+            if (user != null) {
+              cy.getAuth(user).getTenantId();
+            }
 
             const width =
               this.config.global?.viewportWidth ??
@@ -150,10 +155,11 @@ export class C8yScreenshotRunner {
               cy.clock(new Date(visitDate));
             }
 
-            const visitObject = this.getVisitObject(item.visit);
-            const visitUser = visitObject?.user ?? user;
-            cy.login(visitUser);
+            if (user != null) {
+              cy.login(user);
+            }
 
+            const visitObject = this.getVisitObject(item.visit);
             const url = visitObject?.url ?? (item.visit as string);
             const visitSelector =
               visitObject?.selector ??
@@ -167,10 +173,7 @@ export class C8yScreenshotRunner {
             const visitTimeout = visitObject?.timeout;
 
             const language =
-              visitObject?.language ??
-              item.language ??
-              this.config.global?.language ??
-              "en";
+              item.language ?? this.config.global?.language ?? "en";
             cy.visitAndWaitForSelector(
               url,
               language as any,
@@ -222,7 +225,6 @@ export class C8yScreenshotRunner {
     });
   }
 
-
   protected click(action: Action["click"]) {
     const click = _.isString(action) ? { selector: action } : action;
     const selector = getSelector(click);
@@ -239,10 +241,7 @@ export class C8yScreenshotRunner {
     cy.get(selector).type(action.value);
   }
 
-  protected highlight(
-    action: Action["highlight"],
-    that: C8yScreenshotRunner
-  ) {
+  protected highlight(action: Action["highlight"], that: C8yScreenshotRunner) {
     const highlights = _.isArray(action) ? action : [action];
 
     highlights?.forEach((highlight) => {

--- a/src/screenshot/schema.json
+++ b/src/screenshot/schema.json
@@ -470,204 +470,6 @@
             },
             "type": "object"
         },
-        "Screenshot": {
-            "additionalProperties": false,
-            "properties": {
-                "actions": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/Action"
-                        },
-                        {
-                            "items": {
-                                "$ref": "#/definitions/Action"
-                            },
-                            "type": "array"
-                        }
-                    ],
-                    "description": "The actions to perform in the screenshot workflow. The last action\nis always a screenshot action. If no actions are defined or last actions is\nnot a screenshot action, a screenshot is taken of the current state of\nthe application."
-                },
-                "date": {
-                    "description": "The date to simulate when running the screenshot workflows",
-                    "examples": [
-                        "2024-09-26T19:17:35+02:00"
-                    ],
-                    "format": "date-time",
-                    "type": "string"
-                },
-                "highlightStyle": {
-                    "description": "The defaulft style to highlight elements. By default, an organge border of 2px width is used to highlight elements.",
-                    "examples": [
-                        {
-                            "outline": "2px",
-                            "outline-color": "#FF9300",
-                            "outline-offset": "-2px",
-                            "outline-style": "solid"
-                        },
-                        {
-                            "border": "2px solid red"
-                        }
-                    ]
-                },
-                "image": {
-                    "description": "The name of the screenshot image as relative path",
-                    "examples": [
-                        "/images/cockpit/dashboard.png"
-                    ],
-                    "type": "string"
-                },
-                "language": {
-                    "description": "Load Cumulocity with the given language",
-                    "type": "string"
-                },
-                "only": {
-                    "description": "Run only this screenshot workflow and all other workflows that\nhave only setting enabled",
-                    "type": "boolean"
-                },
-                "requires": {
-                    "description": "Requires the shell application to have the a version in the given range.\nThe range must be a valid semver range. If requires is configured and shell\nversion does not fullfill the version requirement, the screenshot workflow\nwill be skipped.",
-                    "examples": [
-                        "1.x, ^1.0.0, >=1.0.0 <2.0.0"
-                    ],
-                    "format": "semver-range",
-                    "type": "string"
-                },
-                "settings": {
-                    "additionalProperties": false,
-                    "description": "The configuration and settings of the screenshot",
-                    "properties": {
-                        "capture": {
-                            "default": "viewport",
-                            "description": "The capturing type for the screenshot. When 'fullPage' is used, the application is captured in its entirety from top to bottom. Setting is ignored when screenshots are taken for a selected DOM element. The default is 'viewport'.\nNote that 'fullPage' screenshots will have a different height than specified in 'viewportHeight'.",
-                            "enum": [
-                                "fullPage",
-                                "viewport"
-                            ],
-                            "examples": [
-                                [
-                                    "viewport",
-                                    "fullPage"
-                                ]
-                            ],
-                            "type": "string"
-                        },
-                        "disableTimersAndAnimations": {
-                            "description": "When true, prevents JavaScript timers (setTimeout, setInterval, etc)\nand CSS animations from running while the screenshot is taken.",
-                            "type": "boolean"
-                        },
-                        "overwrite": {
-                            "description": "Overwrite existing screenshots. By enabling this setting, existing\nscreenshots might be deleted before running the screenshot workflow.",
-                            "type": "boolean"
-                        },
-                        "padding": {
-                            "description": "The padding in px used to alter the dimensions of a screenshot of an\nelement.",
-                            "minimum": 0,
-                            "type": "integer"
-                        },
-                        "scale": {
-                            "description": "Whether to scale the app to fit into the browser viewport.",
-                            "type": "boolean"
-                        },
-                        "timeouts": {
-                            "additionalProperties": false,
-                            "description": "The timeouts supported by Cypress.",
-                            "properties": {
-                                "default": {
-                                    "default": 4000,
-                                    "description": "The time, in milliseconds, to wait until most DOM based commands are\nconsidered timed out.",
-                                    "examples": [
-                                        10000
-                                    ],
-                                    "type": "integer"
-                                },
-                                "pageLoad": {
-                                    "default": 60000,
-                                    "description": "The time, in milliseconds, to wait for the page to load. This is used\nfor visit actions.",
-                                    "examples": [
-                                        30000
-                                    ],
-                                    "type": "integer"
-                                },
-                                "screenshot": {
-                                    "default": 30000,
-                                    "description": "The time, in milliseconds, to wait for a response from a network request.\nAlso applies to screenshot action.",
-                                    "examples": [
-                                        60000
-                                    ],
-                                    "type": "integer"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        "viewportHeight": {
-                            "default": 900,
-                            "description": "The height in px to use for the browser window",
-                            "minimum": 0,
-                            "type": "integer"
-                        },
-                        "viewportWidth": {
-                            "default": 1440,
-                            "description": "The width in px to use for the browser window",
-                            "minimum": 0,
-                            "type": "integer"
-                        }
-                    },
-                    "type": "object"
-                },
-                "shell": {
-                    "description": "The shell is used to dermine the version of the application used by\n\"requires\" (optional)",
-                    "examples": [
-                        "cockpit, devicemanagement, oee"
-                    ],
-                    "type": "string"
-                },
-                "skip": {
-                    "description": "Skip this screenshot workflow",
-                    "type": "boolean"
-                },
-                "tags": {
-                    "description": "Tags allow grouping and filtering of screenshots (optional)",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "user": {
-                    "description": "The login user alias. Configure *user*_username and *user*_password env\nvariables to set the actual user id and password.",
-                    "examples": [
-                        "admin"
-                    ],
-                    "type": "string"
-                },
-                "visit": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/Visit"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ],
-                    "description": "The URI to visit. This typically a relative path to the baseUrl.",
-                    "examples": [
-                        "/apps/cockpit/index.html#/"
-                    ]
-                },
-                "visitWaitSelector": {
-                    "default": "c8y-drawer-outlet c8y-app-icon .c8y-icon",
-                    "description": "The selector to wait for when visiting a page",
-                    "examples": [
-                        "c8y-drawer-outlet c8y-app-icon .c8y-icon"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "image",
-                "visit"
-            ],
-            "type": "object"
-        },
         "ScreenshotClipArea": {
             "additionalProperties": false,
             "properties": {
@@ -696,6 +498,87 @@
                 "x",
                 "y"
             ],
+            "type": "object"
+        },
+        "ScreenshotSettings": {
+            "additionalProperties": false,
+            "properties": {
+                "capture": {
+                    "default": "viewport",
+                    "description": "The capturing type for the screenshot. When 'fullPage' is used, the application is captured in its entirety from top to bottom. Setting is ignored when screenshots are taken for a selected DOM element. The default is 'viewport'.\nNote that 'fullPage' screenshots will have a different height than specified in 'viewportHeight'.",
+                    "enum": [
+                        "fullPage",
+                        "viewport"
+                    ],
+                    "examples": [
+                        [
+                            "viewport",
+                            "fullPage"
+                        ]
+                    ],
+                    "type": "string"
+                },
+                "disableTimersAndAnimations": {
+                    "description": "When true, prevents JavaScript timers (setTimeout, setInterval, etc)\nand CSS animations from running while the screenshot is taken.",
+                    "type": "boolean"
+                },
+                "overwrite": {
+                    "description": "Overwrite existing screenshots. By enabling this setting, existing\nscreenshots might be deleted before running the screenshot workflow.",
+                    "type": "boolean"
+                },
+                "padding": {
+                    "description": "The padding in px used to alter the dimensions of a screenshot of an\nelement.",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "scale": {
+                    "description": "Whether to scale the app to fit into the browser viewport.",
+                    "type": "boolean"
+                },
+                "timeouts": {
+                    "additionalProperties": false,
+                    "description": "The timeouts supported by Cypress.",
+                    "properties": {
+                        "default": {
+                            "default": 4000,
+                            "description": "The time, in milliseconds, to wait until most DOM based commands are\nconsidered timed out.",
+                            "examples": [
+                                10000
+                            ],
+                            "type": "integer"
+                        },
+                        "pageLoad": {
+                            "default": 60000,
+                            "description": "The time, in milliseconds, to wait for the page to load. This is used\nfor visit actions.",
+                            "examples": [
+                                30000
+                            ],
+                            "type": "integer"
+                        },
+                        "screenshot": {
+                            "default": 30000,
+                            "description": "The time, in milliseconds, to wait for a response from a network request.\nAlso applies to screenshot action.",
+                            "examples": [
+                                60000
+                            ],
+                            "type": "integer"
+                        }
+                    },
+                    "type": "object"
+                },
+                "viewportHeight": {
+                    "default": 900,
+                    "description": "The height in px to use for the browser window",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "viewportWidth": {
+                    "default": 1440,
+                    "description": "The width in px to use for the browser window",
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
             "type": "object"
         },
         "SelectableHighlightAction": {
@@ -775,32 +658,6 @@
         "Visit": {
             "additionalProperties": false,
             "properties": {
-                "date": {
-                    "description": "The date to simulate when running the screenshot workflows",
-                    "examples": [
-                        "2024-09-26T19:17:35+02:00"
-                    ],
-                    "format": "date-time",
-                    "type": "string"
-                },
-                "highlightStyle": {
-                    "description": "The defaulft style to highlight elements. By default, an organge border of 2px width is used to highlight elements.",
-                    "examples": [
-                        {
-                            "outline": "2px",
-                            "outline-color": "#FF9300",
-                            "outline-offset": "-2px",
-                            "outline-style": "solid"
-                        },
-                        {
-                            "border": "2px solid red"
-                        }
-                    ]
-                },
-                "language": {
-                    "description": "Load Cumulocity with the given language",
-                    "type": "string"
-                },
                 "selector": {
                     "description": "The selector to wait for before taking the screenshot.",
                     "examples": [
@@ -818,21 +675,6 @@
                 "url": {
                     "description": "The URL to visit. Currently only an URI relative to the base URL is\nsupported.",
                     "format": "uri-reference",
-                    "type": "string"
-                },
-                "user": {
-                    "description": "The login user alias. Configure *user*_username and *user*_password env\nvariables to set the actual user id and password.",
-                    "examples": [
-                        "admin"
-                    ],
-                    "type": "string"
-                },
-                "visitWaitSelector": {
-                    "default": "c8y-drawer-outlet c8y-app-icon .c8y-icon",
-                    "description": "The selector to wait for when visiting a page",
-                    "examples": [
-                        "c8y-drawer-outlet c8y-app-icon .c8y-icon"
-                    ],
                     "type": "string"
                 }
             },
@@ -948,6 +790,13 @@
                     "description": "Load Cumulocity with the given language",
                     "type": "string"
                 },
+                "login": {
+                    "description": "The login user alias. Configure *user*_username and *user*_password env\nvariables to set the actual user id and password.",
+                    "examples": [
+                        "admin"
+                    ],
+                    "type": "string"
+                },
                 "overwrite": {
                     "description": "Overwrite existing screenshots. By enabling this setting, existing\nscreenshots might be deleted before running the screenshot workflow.",
                     "type": "boolean"
@@ -1015,10 +864,7 @@
                     "type": "object"
                 },
                 "user": {
-                    "description": "The login user alias. Configure *user*_username and *user*_password env\nvariables to set the actual user id and password.",
-                    "examples": [
-                        "admin"
-                    ],
+                    "description": "Use login instead of user",
                     "type": "string"
                 },
                 "viewportHeight": {
@@ -1047,7 +893,106 @@
         "screenshots": {
             "description": "The screensht workflows",
             "items": {
-                "$ref": "#/definitions/Screenshot"
+                "additionalProperties": false,
+                "properties": {
+                    "actions": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/Action"
+                            },
+                            {
+                                "items": {
+                                    "$ref": "#/definitions/Action"
+                                },
+                                "type": "array"
+                            }
+                        ],
+                        "description": "The actions to perform in the screenshot workflow. The last action\nis always a screenshot action. If no actions are defined or last actions is\nnot a screenshot action, a screenshot is taken of the current state of\nthe application."
+                    },
+                    "date": {
+                        "description": "The date to simulate when running the screenshot workflows",
+                        "examples": [
+                            "2024-09-26T19:17:35+02:00"
+                        ],
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "image": {
+                        "description": "The name of the screenshot image as relative path",
+                        "examples": [
+                            "/images/cockpit/dashboard.png"
+                        ],
+                        "type": "string"
+                    },
+                    "language": {
+                        "description": "Load Cumulocity with the given language",
+                        "type": "string"
+                    },
+                    "login": {
+                        "description": "The login user alias. Configure *user*_username and *user*_password env\nvariables to set the actual user id and password.",
+                        "examples": [
+                            "admin"
+                        ],
+                        "type": "string"
+                    },
+                    "only": {
+                        "description": "Run only this screenshot workflow and all other workflows that\nhave only setting enabled",
+                        "type": "boolean"
+                    },
+                    "requires": {
+                        "description": "Requires the shell application to have the a version in the given range.\nThe range must be a valid semver range. If requires is configured and shell\nversion does not fullfill the version requirement, the screenshot workflow\nwill be skipped.",
+                        "examples": [
+                            "1.x, ^1.0.0, >=1.0.0 <2.0.0"
+                        ],
+                        "format": "semver-range",
+                        "type": "string"
+                    },
+                    "settings": {
+                        "$ref": "#/definitions/ScreenshotSettings",
+                        "description": "The configuration and settings of the screenshot"
+                    },
+                    "shell": {
+                        "description": "The shell is used to dermine the version of the application used by\n\"requires\" (optional)",
+                        "examples": [
+                            "cockpit, devicemanagement, oee"
+                        ],
+                        "type": "string"
+                    },
+                    "skip": {
+                        "description": "Skip this screenshot workflow",
+                        "type": "boolean"
+                    },
+                    "tags": {
+                        "description": "Tags allow grouping and filtering of screenshots (optional)",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "user": {
+                        "description": "Use login instead of user",
+                        "type": "string"
+                    },
+                    "visit": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/Visit"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "description": "The URI to visit. This typically a relative path to the baseUrl.",
+                        "examples": [
+                            "/apps/cockpit/index.html#/"
+                        ]
+                    }
+                },
+                "required": [
+                    "image",
+                    "visit"
+                ],
+                "type": "object"
             },
             "type": "array"
         },


### PR DESCRIPTION
Use `login` instead of `user`. If no login user alias is configured, the login will be skipped. This is to enable screenshot workflows for public resources.