### PR TITLE
fix(c8yscrn): Allow highlighting multiple elements with single border

### DIFF
--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -295,10 +295,10 @@ export interface UploadFileAction {
 
 export interface HighlightAction {
   /**
-   * The border style. Use any valid CSS border style.
+   * The border style. Use any valid CSS border style. If provided an object, keys override the default border style.
    * @examples ["1px solid red"]
    */
-  border?: string;
+  border?: string | any;
   /**
    * The CSS styles to apply to the DOM element. Use any valid CSS styles.
    * @examples ["background-color: yellow", "outline: dashed", "outline-offset: +3px"]

--- a/src/screenshot/schema.json
+++ b/src/screenshot/schema.json
@@ -212,8 +212,7 @@
                                     "description": "The border style. Use any valid CSS border style.",
                                     "examples": [
                                         "1px solid red"
-                                    ],
-                                    "type": "string"
+                                    ]
                                 },
                                 "selector": {
                                     "anyOf": [
@@ -255,8 +254,7 @@
                                     "description": "The border style. Use any valid CSS border style.",
                                     "examples": [
                                         "1px solid red"
-                                    ],
-                                    "type": "string"
+                                    ]
                                 },
                                 "data-cy": {
                                     "type": "string"
@@ -590,8 +588,7 @@
                             "description": "The border style. Use any valid CSS border style.",
                             "examples": [
                                 "1px solid red"
-                            ],
-                            "type": "string"
+                            ]
                         },
                         "selector": {
                             "anyOf": [
@@ -633,8 +630,7 @@
                             "description": "The border style. Use any valid CSS border style.",
                             "examples": [
                                 "1px solid red"
-                            ],
-                            "type": "string"
+                            ]
                         },
                         "data-cy": {
                             "type": "string"


### PR DESCRIPTION
When highlighting selectors matching multiple elements, each of the elements has been highlighted separately. Now the style is applied to the union rect of all elements. The `border` and `styles` properties are both applied, giving more flexibility when highlighting elements. `border` now also allows overriding the individual properties of the default settings, e.g. using `"outline-offset": "6px"`.