### PR TITLE
fix(c8yscrn): Allow definition of reusable selectors

### DIFF
--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -20,6 +20,10 @@ export type ScreenshotSetup = {
    */
   global?: GlobalOptions & ScreenshotSettings & ScreenshotOptions;
   /**
+   * Definition of shared selectors to use in the screenshot workflows
+   */
+  selectors?: SharedSelector | SharedSelector[];
+  /**
    * The screensht workflows
    */
   screenshots: (Screenshot & ScreenshotOptions)[];
@@ -164,7 +168,7 @@ export interface ScreenshotSettings {
   /**
    * Options to configure the diffing of screenshots.
    */
-  diff?: Omit<DiffOptions, "targetFolder" | "skipMove">;
+  diff?: ForwardedOdiffOptions;
   /**
    * The timeouts supported by Cypress.
    */
@@ -196,7 +200,7 @@ export interface ScreenshotSettings {
   };
 }
 
-export interface DiffOptions
+interface ForwardedOdiffOptions
   extends Pick<
     ODiffOptions,
     | "threshold"
@@ -204,9 +208,11 @@ export interface DiffOptions
     | "antialiasing"
     | "diffColor"
     | "outputDiffMask"
-  > {
-    targetFolder?: string;
-    skipMove?: boolean;
+  > {}
+
+export interface DiffOptions extends ForwardedOdiffOptions {
+  targetFolder?: string;
+  skipMove?: boolean;
 }
 
 export interface Visit {
@@ -418,6 +424,10 @@ export type Selector = {
 };
 
 export type Selectable = Selector | DataCySelector;
+
+export type SharedSelector = {
+  [key: string]: string;
+};
 
 // Internal types used within C8yScreenshotRunner
 // This will not be exposed to schema.json

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -194,8 +194,11 @@ export function configureC8yScreenshotPlugin(
     );
   }
 
-  const ajv = new C8yAjvSchemaMatcher();
-  ajv.match(configData, schema, true);
+  const schemaMatcher = new C8yAjvSchemaMatcher();
+  const valid = schemaMatcher.ajv.validate(schema, configData);
+  if (!valid) {
+    throw new Error(`Invalid config file. ${schemaMatcher.ajv.errorsText()}`);
+  }
 
   if (configData.global?.timeouts?.default) {
     config.defaultCommandTimeout = configData.global.timeouts.default;

--- a/src/screenshot/runner-helper.spec.ts
+++ b/src/screenshot/runner-helper.spec.ts
@@ -1,0 +1,42 @@
+/// <reference types="jest" />
+
+import {
+  getSelector,
+} from "./runner-helper";
+import { ScreenshotSetup } from "../lib/screenshots/types";
+
+describe("startup", () => {
+  describe("getSelector", () => {
+    const predefinedSelectors: ScreenshotSetup["selectors"] = [
+      { name: "testSelector", selector: ".test-class" },
+    ];
+
+    it("should return the selector string if input is a string", () => {
+      const result = getSelector("testSelector", predefinedSelectors);
+      expect(result).toBe(".test-class");
+    });
+
+    it("should return the data-cy attribute if input is an object with data-cy", () => {
+      const selector = { "data-cy": "test-cy" };
+      const result = getSelector(selector, predefinedSelectors);
+      expect(result).toBe("[data-cy=test-cy]");
+    });
+
+    it("should return the nested selector if input is an object with selector", () => {
+      const selector = { selector: ".my-test-class" };
+      const result = getSelector(selector, predefinedSelectors);
+      expect(result).toBe(".my-test-class");
+    });
+
+    it("should return undefined if input is undefined", () => {
+      const result = getSelector(undefined, predefinedSelectors);
+      expect(result).toBeUndefined();
+    });
+
+    it("should return the input string if it does not match any predefined selectors", () => {
+      const selector = "nonExistentSelector";
+      const result = getSelector(selector, predefinedSelectors);
+      expect(result).toBe("nonExistentSelector");
+    });
+  });
+});

--- a/src/screenshot/runner-helper.ts
+++ b/src/screenshot/runner-helper.ts
@@ -1,0 +1,29 @@
+import _ from "lodash";
+
+import { ScreenshotSetup, Selector } from "../lib/screenshots/types";
+
+export function getSelector(
+  selector: any | string | undefined,
+  predefined?: ScreenshotSetup["selectors"]
+): string | undefined {
+  if (!selector) return undefined;
+  if (_.isString(selector)) {
+    const sharedSelector = _.isArrayLike(predefined)
+      ? _.first(predefined.filter((s) => s.name === selector))?.selector
+      : _.get(predefined, selector);
+    return sharedSelector ?? selector;
+  }
+  if (_.isPlainObject(selector)) {
+    if ("data-cy" in selector) {
+      return `[data-cy=${_.get(selector, "data-cy")}]`;
+    }
+    if ("selector" in selector) {
+      return getSelector(selector.selector as Selector, predefined);
+    }
+  }
+  return undefined;
+}
+
+export function imageName(name: string): string {
+  return name.replace(/.png$/i, "");
+}

--- a/src/screenshot/schema.json
+++ b/src/screenshot/schema.json
@@ -484,7 +484,7 @@
             },
             "type": "object"
         },
-        "Omit<DiffOptions,\"targetFolder\"|\"skipMove\">": {
+        "ForwardedOdiffOptions": {
             "additionalProperties": false,
             "properties": {
                 "antialiasing": {
@@ -583,7 +583,7 @@
                     "type": "string"
                 },
                 "diff": {
-                    "$ref": "#/definitions/Omit<DiffOptions,\"targetFolder\"|\"skipMove\">",
+                    "$ref": "#/definitions/ForwardedOdiffOptions",
                     "description": "Options to configure the diffing of screenshots."
                 },
                 "disableTimersAndAnimations": {
@@ -851,7 +851,7 @@
                     "type": "string"
                 },
                 "diff": {
-                    "$ref": "#/definitions/Omit<DiffOptions,\"targetFolder\"|\"skipMove\">",
+                    "$ref": "#/definitions/ForwardedOdiffOptions",
                     "description": "Options to configure the diffing of screenshots."
                 },
                 "disableTimersAndAnimations": {
@@ -1081,6 +1081,26 @@
                 "type": "object"
             },
             "type": "array"
+        },
+        "selectors": {
+            "anyOf": [
+                {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                },
+                {
+                    "items": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "type": "object"
+                    },
+                    "type": "array"
+                }
+            ],
+            "description": "Definition of shared selectors to use in the screenshot workflows"
         },
         "title": {
             "description": "The title used for root group of screenshot workflows",

--- a/src/screenshot/startup.ts
+++ b/src/screenshot/startup.ts
@@ -72,12 +72,11 @@ const log = debug("c8y:scrn:startup");
       throw new Error(`Error reading config file. ${error.message}`);
     }
 
-    try {
-      log(`Validating config file ${yamlFile}`);
-      const ajv = new C8yAjvSchemaMatcher();
-      ajv.match(configData, schema, true);
-    } catch (error: any) {
-      throw new Error(`Invalid config file. ${error.message}`);
+    log(`Validating config file ${yamlFile}`);
+    const schemaMatcher = new C8yAjvSchemaMatcher();
+    const valid = schemaMatcher.ajv.validate(schema, configData);
+    if (!valid) {
+      throw new Error(`Invalid config file. ${schemaMatcher.ajv.errorsText()}`);
     }
 
     baseUrl = baseUrl ?? configData.baseUrl ?? "http://localhost:8080";


### PR DESCRIPTION
Reusable selector definitions should help organizing workflows and keep them more readable and maintainable. Define reusable selectors as new root array or object `selectors` in the config yaml file. This is especially helpful if there are no `data-cy` attributes for the DOM element referenced by your workflow. Example:

``` yaml
selectors:
  - treeview.collapse.first: ".c8y-tree-view-node .collapse-btn:first"
  - treeview.collapse.first.checkbox: "c8y-tree-view-node:has(.collapse-btn:visible:first) .c8y-checkbox:first"
```