### PR TITLE
fix(c8yscrn): Support multiple textfields with one type action

### DIFF
--- a/doc/Screenshot Automation.md
+++ b/doc/Screenshot Automation.md
@@ -668,9 +668,28 @@ Clicks on the specified element. Use the `multiple` option to click on all match
 ```yaml
 - type:
     selector: string or object
-    value: string
+    value: string | string[]
+    clear: boolean
 ```
-Types the specified value into the selected input field.
+
+Types the specified value into the selected input field. If the `clear` option is set to true, the input field will be cleared before typing the new value. If the `value` is an array, the values will be typed in sequence into the text input fields with the selector.
+
+```yaml
+- type:
+    selector: "#search"
+    value: "Test Search"
+- type:
+    selector: ".split-view__detail"
+    value:
+      - "Windmill"
+      - "Turns wind into energy"
+- type:
+    selector: ".split-view__detail"
+    value: ["Windmill", "Turns wind into energy"]
+    clear: true
+```
+
+The array of values might have more elements than the number of text input fields with the selector. In this case, the remaining values are ignored.
 
 **highlight**
 ```yaml

--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -234,9 +234,14 @@ export interface ClickAction {
 
 export interface TypeAction {
   /**
-   * The value to type
+   * The value to type into the selected DOM element. The value can be a string or an array of strings. If an array is provided, textfields within the selector are filled with the values in the array.
    */
-  value: string;
+  value: string | string[];
+  /**
+   * If true, the text input is cleared before typing. The default is false.
+   * @default false
+   */
+  clear?: boolean;
 }
 
 export interface TextAction {

--- a/src/screenshot/runner.ts
+++ b/src/screenshot/runner.ts
@@ -249,7 +249,25 @@ export class C8yScreenshotRunner {
   protected type(action: Action["type"]) {
     const selector = getSelector(action, this.config.selectors);
     if (selector == null || action == null) return;
-    cy.get(selector).type(action.value);
+    if (_.isString(action.value)) {
+      if (action.clear === true) {
+        cy.get(selector).clear();
+      }
+      cy.get(selector).type(action.value);
+    } else if (_.isArrayLike(action.value)) {
+      cy.get(selector).within(() => {
+        cy.get("input[type=text]").then(($elements) => {
+          const length = Math.min($elements.length, action.value.length);
+          (action.value as string[]).forEach((value: string, index: number) => {
+            if (index >= length) return;
+            if (action.clear === true) {
+              cy.get(selector).clear();
+            }
+            cy.get("input[type=text]").eq(index).type(value);
+          });
+        });
+      });
+    }
   }
 
   protected highlight(action: Action["highlight"], that: C8yScreenshotRunner) {

--- a/src/screenshot/schema.json
+++ b/src/screenshot/schema.json
@@ -420,6 +420,11 @@
                         {
                             "additionalProperties": false,
                             "properties": {
+                                "clear": {
+                                    "default": false,
+                                    "description": "If true, the text input is cleared before typing. The default is false.",
+                                    "type": "boolean"
+                                },
                                 "selector": {
                                     "anyOf": [
                                         {
@@ -440,8 +445,18 @@
                                     ]
                                 },
                                 "value": {
-                                    "description": "The value to type",
-                                    "type": "string"
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The value to type into the selected DOM element. The value can be a string or an array of strings. If an array is provided, textfields within the selector are filled with the values in the array."
                                 }
                             },
                             "required": [
@@ -453,12 +468,27 @@
                         {
                             "additionalProperties": false,
                             "properties": {
+                                "clear": {
+                                    "default": false,
+                                    "description": "If true, the text input is cleared before typing. The default is false.",
+                                    "type": "boolean"
+                                },
                                 "data-cy": {
                                     "type": "string"
                                 },
                                 "value": {
-                                    "description": "The value to type",
-                                    "type": "string"
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The value to type into the selected DOM element. The value can be a string or an array of strings. If an array is provided, textfields within the selector are filled with the values in the array."
                                 }
                             },
                             "required": [
@@ -881,22 +911,27 @@
                     ]
                 },
                 "language": {
-                    "description": "Load dddCumulocity with the given language",
+                    "description": "Load Cumulocity with the given language",
                     "type": "string"
                 },
                 "login": {
                     "anyOf": [
                         {
-                            "const": false,
+                            "enum": [
+                                false
+                            ],
                             "type": "boolean"
                         },
                         {
                             "type": "string"
                         }
                     ],
-                    "description": "The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password. If set to false, login is disabled and visit is performed unauthenticated.",
+                    "description": "The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password env variables. If set to false, login is disabled and visit is performed unauthenticated.",
                     "examples": [
-                        "admin"
+                        [
+                            "admin",
+                            false
+                        ]
                     ]
                 },
                 "overwrite": {
@@ -1027,22 +1062,27 @@
                         "type": "string"
                     },
                     "language": {
-                        "description": "Load dddCumulocity with the given language",
+                        "description": "Load Cumulocity with the given language",
                         "type": "string"
                     },
                     "login": {
                         "anyOf": [
                             {
-                                "const": false,
+                                "enum": [
+                                    false
+                                ],
                                 "type": "boolean"
                             },
                             {
                                 "type": "string"
                             }
                         ],
-                        "description": "The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password. If set to false, login is disabled and visit is performed unauthenticated.",
+                        "description": "The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password env variables. If set to false, login is disabled and visit is performed unauthenticated.",
                         "examples": [
-                            "admin"
+                            [
+                                "admin",
+                                false
+                            ]
                         ]
                     },
                     "only": {


### PR DESCRIPTION
Support typing text into multiple textfields with a single type action. Provide array of strings as value to type values in sequence into all text fields within the selector.