### PR TITLE
fix(c8yscrn): ScreenshotAction string value for path

### DIFF
--- a/doc/Screenshot Automation.md
+++ b/doc/Screenshot Automation.md
@@ -735,7 +735,7 @@ If no selector is provided, the file will be uploaded to the first file input fi
 
 **screenshot**
 ```yaml
-- screenshot:
+- screenshot: string or object
     selector: string or object
     clip:
       x: number
@@ -745,6 +745,8 @@ If no selector is provided, the file will be uploaded to the first file input fi
     path: string
 ```
 Takes a screenshot with specific options. If used within the `actions` array, this allows for multiple screenshots within a single workflow.
+
+If a string is passed to screenshot, it will be used as the path for the screenshot.
 
 **text**
 ```yaml

--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -379,7 +379,7 @@ export interface Action {
   /**
    * The screenshot action triggers a screenshot of the current state of the application.
    */
-  screenshot?: ScreenshotAction & Partial<Selectable>;
+  screenshot?: string | ScreenshotAction & Partial<Selectable>;
   /**
    * A text action modifies the text value of selected DOM element.
    */

--- a/src/screenshot/runner.ts
+++ b/src/screenshot/runner.ts
@@ -200,7 +200,10 @@ export class C8yScreenshotRunner {
               const handlerKey = Object.keys(action)[0];
               const handler = this.actionHandlers[handlerKey];
               if (handler) {
-                if (isScreenshotAction(action)) {
+                if (
+                  isScreenshotAction(action) &&
+                  !_.isString(action.screenshot)
+                ) {
                   const clipArea = action.screenshot?.clip;
                   if (clipArea) {
                     options["clip"] = {
@@ -499,19 +502,19 @@ export class C8yScreenshotRunner {
     item: Screenshot,
     options: any
   ) {
-    let name = action?.path || item.image;
-    const selector = getSelector(action, this.config.selectors);
-    cy.task(
-      "debug",
-      `Taking screenshot ${name} Selector: ${selector}`,
-      taskLog
-    );
+    const name = _.isString(action) ? action : action?.path ?? item.image;
+    const selector = !_.isString(action)
+      ? getSelector(action, this.config.selectors)
+      : undefined;
+
+    const logmessage = `Taking screenshot ${name} Selector: ${selector}`;
+    cy.task("debug", logmessage, taskLog);
     cy.task("debug", `Options: ${JSON.stringify(options)}`, taskLog);
-    name = imageName(name);
+    
     if (selector != null) {
-      cy.get(selector).screenshot(name, options);
+      cy.get(selector).screenshot(imageName(name), options);
     } else {
-      cy.screenshot(name, options);
+      cy.screenshot(imageName(name), options);
     }
   }
 

--- a/src/screenshot/schema.json
+++ b/src/screenshot/schema.json
@@ -356,6 +356,9 @@
                                 }
                             },
                             "type": "object"
+                        },
+                        {
+                            "type": "string"
                         }
                     ],
                     "description": "The screenshot action triggers a screenshot of the current state of the application."


### PR DESCRIPTION
The `screenshot` action now allows to pass a string directly instead of the `path` for the screenshot name. 
```yaml
  - screenshot:
      path: path/to/my/screenshot.png 
  - screenshot: path/to/my/screenshot.png 
```