### PR TITLE
fix(c8yscrn): Fix highlighting elements with parents having 0 bounding rect

### DIFF
--- a/src/screenshot/runner-helper.ts
+++ b/src/screenshot/runner-helper.ts
@@ -30,7 +30,7 @@ export function findCommonParent(
   if (!$elements || $elements.length === 0) return undefined;
 
   const getParents = (element: HTMLElement) => {
-    const parents = [];
+    const parents: HTMLElement[] = [];
     while (element.parentElement) {
       parents.push(element.parentElement);
       element = element.parentElement;
@@ -41,13 +41,50 @@ export function findCommonParent(
   const firstElementParents = getParents($elements[0]);
   for (const parent of firstElementParents) {
     const isCommonParent = Array.from($elements).every((el) =>
-      el.closest(parent.tagName.toLowerCase())
+      hasParent(el, parent)
     );
-    if (isCommonParent === true) {
+    const r = parent.getBoundingClientRect();
+    // When an element has display: contents, it is rendered as if it weren't there
+    // at all. Its children are rendered as if they were direct children of its parent. 
+    // This means that the element itself doesn't have a bounding rectangle, which is 
+    // why getBoundingClientRect() returns 0 for all values.
+    // Make sure that the parent has a width and height so the parent is actually visible
+    if (isCommonParent === true && (r.width > 0 && r.height > 0)) {
       return parent;
     }
   }
   return undefined;
+}
+
+/**
+ * Checks if an element has a specific parent element
+ * @param {HTMLElement} element - The element to check
+ * @param {HTMLElement} parent - The parent element to check for
+ * @returns {boolean} - True if the element has the parent element
+ */
+export function hasParent(element: HTMLElement, parent: HTMLElement): boolean {
+  let currentElement = element;
+
+  while (currentElement.parentElement) {
+    if (currentElement.parentElement === parent) {
+      return true;
+    }
+    currentElement = currentElement.parentElement;
+  }
+
+  return false;
+}
+
+export function getElementPositionWithinParent($e: HTMLElement, $p: HTMLElement) {
+  const childRect = $e.getBoundingClientRect();
+  const parentRect = $p.getBoundingClientRect();
+
+  return new DOMRectReadOnly(
+    childRect.left - parentRect.left,
+    childRect.top - parentRect.top,
+    childRect.width,
+    childRect.height
+  );
 }
 
 /**

--- a/src/screenshot/runner.ts
+++ b/src/screenshot/runner.ts
@@ -14,7 +14,12 @@ import {
 
 import { C8yAjvSchemaMatcher } from "../contrib/ajv";
 import schema from "./schema.json";
-import { findCommonParent, getSelector, imageName } from "./runner-helper";
+import {
+  findCommonParent,
+  getElementPositionWithinParent,
+  getSelector,
+  imageName,
+} from "./runner-helper";
 
 const { _ } = Cypress;
 
@@ -289,18 +294,6 @@ export class C8yScreenshotRunner {
         "outline-color": "#FF9300",
       };
 
-      const getPosition = ($e: HTMLElement, $p: HTMLElement) => {
-        const childRect = $e.getBoundingClientRect();
-        const parentRect = $p.getBoundingClientRect();
-
-        return new DOMRectReadOnly(
-          childRect.left - parentRect.left,
-          childRect.top - parentRect.top,
-          childRect.width,
-          childRect.height
-        );
-      };
-
       const applyHighlightStyle = (
         $element: JQuery<HTMLElement>,
         styles: any
@@ -323,11 +316,9 @@ export class C8yScreenshotRunner {
               Cypress.$($parent).css("position", "relative");
             }
 
-            const firstRect = getPosition($element[0], $parent);
-            const lastRect = getPosition(
-              $element[$element.length - 1],
-              $parent
-            );
+            const getRect = getElementPositionWithinParent;
+            const firstRect = getRect($element[0], $parent);
+            const lastRect = getRect($element[$element.length - 1], $parent);
 
             let width = lastRect.right - firstRect.left;
             if (!_.isString(highlight) && highlight?.width != null) {
@@ -510,7 +501,7 @@ export class C8yScreenshotRunner {
     const logmessage = `Taking screenshot ${name} Selector: ${selector}`;
     cy.task("debug", logmessage, taskLog);
     cy.task("debug", `Options: ${JSON.stringify(options)}`, taskLog);
-    
+
     if (selector != null) {
       cy.get(selector).screenshot(imageName(name), options);
     } else {


### PR DESCRIPTION
When elements have parents that for example have `display: contents` set, the parents are actually not visible and have a 0 bounding rect. This could break calculation of highlight rect if selector matches multiple DOM elements. Now parents with 0 bounding rect are ignored.