### PR TITLE
fix(command): Fix hideCookieBanner command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,34 +6,36 @@ Contribute by raising pull requests. All commands must be documented and, if pos
 
 # Content
 <!-- set markdown.extension.toc.levels 2..6 - level 1 is ignored in auto generated toc -->
-- [Overview of commands](#overview-of-commands)
-- [Screenshot automation](#screenshot-automation)
-- [Installation and setup](#installation-and-setup)
-  - [Peer dependencies](#peer-dependencies)
-  - [Load plugin](#load-plugin)
-  - [Import commands](#import-commands)
-  - [Environment variables](#environment-variables)
-- [Additional frameworks](#additional-frameworks)
-- [Concepts](#concepts)
-  - [Authentication and credentials](#authentication-and-credentials)
-    - [Authentication via getAuth and useAuth commands](#authentication-via-getauth-and-useauth-commands)
-    - [Authentication via test case annotations](#authentication-via-test-case-annotations)
-    - [Authentication via environment variables](#authentication-via-environment-variables)
-    - [Passing authentication to cy.request](#passing-authentication-to-cyrequest)
-  - [Chaining of commands](#chaining-of-commands)
-  - [c8y/client and Web SDK types](#c8yclient-and-web-sdk-types)
-  - [Recording of requests and responses](#recording-of-requests-and-responses)
-  - [Component testing](#component-testing)
-- [Development](#development)
-  - [Debugging](#debugging)
-    - [Console log debugging](#console-log-debugging)
-    - [Debugging in Visual Studio Code](#debugging-in-visual-studio-code)
-  - [Testing](#testing)
-    - [Test access of DOM elements](#test-access-of-dom-elements)
-    - [Test requests](#test-requests)
-    - [Test interceptions](#test-interceptions)
-- [Useful links](#useful-links)
-- [Disclaimer](#disclaimer)
+- [Cypress commands for Cumulocity](#cypress-commands-for-cumulocity)
+- [Content](#content)
+  - [Overview of commands](#overview-of-commands)
+  - [Screenshot automation](#screenshot-automation)
+  - [Installation and setup](#installation-and-setup)
+    - [Peer dependencies](#peer-dependencies)
+    - [Load plugin](#load-plugin)
+    - [Import commands](#import-commands)
+    - [Environment variables](#environment-variables)
+  - [Additional frameworks](#additional-frameworks)
+  - [Concepts](#concepts)
+    - [Authentication and credentials](#authentication-and-credentials)
+      - [Authentication via getAuth and useAuth commands](#authentication-via-getauth-and-useauth-commands)
+      - [Authentication via test case annotations](#authentication-via-test-case-annotations)
+      - [Authentication via environment variables](#authentication-via-environment-variables)
+      - [Passing authentication to cy.request](#passing-authentication-to-cyrequest)
+    - [Chaining of commands](#chaining-of-commands)
+    - [c8y/client and Web SDK types](#c8yclient-and-web-sdk-types)
+    - [Recording of requests and responses](#recording-of-requests-and-responses)
+    - [Component testing](#component-testing)
+  - [Development](#development)
+    - [Debugging](#debugging)
+      - [Console log debugging](#console-log-debugging)
+      - [Debugging in Visual Studio Code](#debugging-in-visual-studio-code)
+    - [Testing](#testing)
+      - [Test access of DOM elements](#test-access-of-dom-elements)
+      - [Test requests](#test-requests)
+      - [Test interceptions](#test-interceptions)
+  - [Useful links](#useful-links)
+  - [Disclaimer](#disclaimer)
 
 ## Overview of commands
 
@@ -43,7 +45,7 @@ General commands
 
 - `visitAndWaitForSelector`
 - `setLanguage`
-- `hideCookieBanner`
+- `hideCookieBanner`, `acceptCookieBanner`
 - `disableGainsights`
 
 Authentication related commands

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ General commands
 
 - `visitAndWaitForSelector`
 - `setLanguage`
-- `hideCookieBanner`, `acceptCookieBanner`
-- `disableGainsights`
+- `hideCookieBanner`, `acceptCookieBanner`, `showCookieBanner`
+- `disableGainsight`
 
 Authentication related commands
 - `login`

--- a/src/lib/commands/login.ts
+++ b/src/lib/commands/login.ts
@@ -102,6 +102,10 @@ Cypress.Commands.add("login", { prevSubject: "optional" }, (...args) => {
       consoleProps.options = options || null;
 
       const loginRequest = (tenant: string) => {
+        // cookie banner adds interception, set before login
+        if (options.hideCookieBanner === true) {
+          cy.hideCookieBanner();
+        }
         return cy
           .request({
             method: "POST",
@@ -118,9 +122,6 @@ Cypress.Commands.add("login", { prevSubject: "optional" }, (...args) => {
             expect(resp).to.have.property("headers");
             if (options.disableGainsight === true) {
               cy.disableGainsight();
-            }
-            if (options.hideCookieBanner === true) {
-              cy.hideCookieBanner();
             }
           });
       };

--- a/test/cypress/app/apps/public/public-options/options.json
+++ b/test/cypress/app/apps/public/public-options/options.json
@@ -1,0 +1,14 @@
+{
+    "cookieBanner": {
+        "cookieBannerTitle": "About cookies on this website",
+        "cookieBannerText": "Cookies are important to the proper functioning of a site. To improve your experience, we use cookies to remember log-in details and provide secure log-in, collect statistics to optimize site functionality, and deliver content tailored to your interests. Click Agree and Proceed to accept all cookies and go directly to the site or click Configure preferences for further details and to manage your options. The consent can be revoked at any time.",
+        "policyUrl": "https://www.softwareag.com/en_corporate/privacy.html",
+        "cookieBannerDisabled": false,
+        "policyVersion": "2"
+    },
+    "cookiePreferences": {
+        "required": true,
+        "functional": "These cookies are used to support you during your first steps in the product, to deliver content tailored to your needs, and to collect usage statistics."
+    },
+    "lastUpdated": "2024-10-24T12:32:15.558Z"
+}

--- a/test/cypress/app/apps/public/public-options@app-cockpit/options.json
+++ b/test/cypress/app/apps/public/public-options@app-cockpit/options.json
@@ -1,0 +1,14 @@
+{
+    "cookieBanner": {
+        "cookieBannerTitle": "About cookies on this website",
+        "cookieBannerText": "Cookies are important to the proper functioning of a site. To improve your experience, we use cookies to remember log-in details and provide secure log-in, collect statistics to optimize site functionality, and deliver content tailored to your interests. Click Agree and Proceed to accept all cookies and go directly to the site or click Configure preferences for further details and to manage your options. The consent can be revoked at any time.",
+        "policyUrl": "https://www.softwareag.com/en_corporate/privacy.html",
+        "cookieBannerDisabled": false,
+        "policyVersion": "2"
+    },
+    "cookiePreferences": {
+        "required": true,
+        "functional": "These cookies are used to support you during your first steps in the product, to deliver content tailored to your needs, and to collect usage statistics."
+    },
+    "lastUpdated": "2024-10-24T12:32:15.558Z"
+}

--- a/test/cypress/app/apps/public/public-options@app-cockpit/options.json
+++ b/test/cypress/app/apps/public/public-options@app-cockpit/options.json
@@ -1,14 +1,12 @@
 {
     "cookieBanner": {
-        "cookieBannerTitle": "About cookies on this website",
-        "cookieBannerText": "Cookies are important to the proper functioning of a site. To improve your experience, we use cookies to remember log-in details and provide secure log-in, collect statistics to optimize site functionality, and deliver content tailored to your interests. Click Agree and Proceed to accept all cookies and go directly to the site or click Configure preferences for further details and to manage your options. The consent can be revoked at any time.",
-        "policyUrl": "https://www.softwareag.com/en_corporate/privacy.html",
-        "cookieBannerDisabled": false,
-        "policyVersion": "2"
+      "cookieBannerTitle": "About cookies on this website",
+      "cookieBannerText": "Cookies are important to the proper functioning of a site. To improve your experience, we use cookies to remember log-in details and provide secure log-in, collect statistics to optimize site functionality, and deliver content tailored to your interests. Click Agree and Proceed to accept all cookies and go directly to the site or click Configure preferences for further details and to manage your options. The consent can be revoked at any time.",
+      "policyUrl": "https://cumulocity.com/docs/legal-notices/privacy-notice/",
+      "policyVersion": "2024-12-03"
     },
     "cookiePreferences": {
-        "required": true,
-        "functional": "These cookies are used to support you during your first steps in the product, to deliver content tailored to your needs, and to collect usage statistics."
-    },
-    "lastUpdated": "2024-10-24T12:32:15.558Z"
-}
+      "required": true,
+      "functional": "These cookies are used to support you during your first steps in the product, to deliver content tailored to your needs, and to collect usage statistics."
+    }
+  }

--- a/test/cypress/e2e/general.cy.ts
+++ b/test/cypress/e2e/general.cy.ts
@@ -94,6 +94,22 @@ describe("general", () => {
           });
         });
     });
+
+    it("showCookieBanner should remove acceptCookieNotice", () => {
+      cy.acceptCookieBanner(false, false, false).then(() => {
+        cy.window().then((win) => {
+          const cookie = win.localStorage.getItem("acceptCookieNotice");
+          expect(cookie).to.be.not.null;
+        });
+      });
+
+      cy.showCookieBanner().then(() => {
+        cy.window().then((win) => {
+          const cookie = win.localStorage.getItem("acceptCookieNotice");
+          expect(cookie).to.be.null;
+        });
+      });
+    });
   });
 
   context("setLanguage", () => {

--- a/test/cypress/e2e/general.cy.ts
+++ b/test/cypress/e2e/general.cy.ts
@@ -31,21 +31,68 @@ describe("general", () => {
     });
   });
 
-  context("hideCookieBanner", () => {
-    it("hideCookieBanner should update localStorage cookie value", () => {
+  context("CookieBanner", () => {
+    beforeEach(() => {
       cy.window().then((win) => {
         const cookie = win.localStorage.getItem("acceptCookieNotice");
         expect(cookie).to.be.null;
       });
+    });
 
-      cy.hideCookieBanner();
+    it("hideCookieBanner should configure acceptCookieNotice", () => {
+      cy.hideCookieBanner()
+        .as("interception")
+        .then(() => $.get(url(`/apps/public/public-options/options.json?_=a`)))
+        .then(() => {
+          cy.window().then((win) => {
+            const cookie = win.localStorage.getItem("acceptCookieNotice");
+            expect(cookie).to.be.not.null;
+            expect(JSON.parse(cookie!)).to.deep.eq({
+              required: true,
+              functional: true,
+              marketing: true,
+              policyVersion: "2",
+            });
+          });
+        });
+    });
 
-      cy.window().then((win) => {
-        const cookie = JSON.parse(
-          win.localStorage.getItem("acceptCookieNotice")!
-        );
-        expect(cookie).to.deep.eq({ required: true, functional: true });
-      });
+    it("acceptCookieBanner should configure acceptCookieNotice", () => {
+      cy.acceptCookieBanner(false, false, false)
+        .as("interception")
+        .then(() => $.get(url(`/apps/public/public-options/options.json?_=b`)))
+        .then(() => {
+          cy.window().then((win) => {
+            const cookie = win.localStorage.getItem("acceptCookieNotice");
+            expect(cookie).to.be.not.null;
+            expect(JSON.parse(cookie!)).to.deep.eq({
+              required: false,
+              functional: false,
+              marketing: false,
+              policyVersion: "2",
+            });
+          });
+        });
+    });
+
+    it("acceptCookieBanner should intercept app options", () => {
+      cy.acceptCookieBanner(false, false, true)
+        .as("interception")
+        .then(() =>
+          $.get(url(`/apps/public/public-options@app-cockpit/options.json?_=c`))
+        )
+        .then(() => {
+          cy.window().then((win) => {
+            const cookie = win.localStorage.getItem("acceptCookieNotice");
+            expect(cookie).to.be.not.null;
+            expect(JSON.parse(cookie!)).to.deep.eq({
+              required: false,
+              functional: false,
+              marketing: true,
+              policyVersion: "2",
+            });
+          });
+        });
     });
   });
 

--- a/test/cypress/e2e/general.cy.ts
+++ b/test/cypress/e2e/general.cy.ts
@@ -89,7 +89,7 @@ describe("general", () => {
               required: false,
               functional: false,
               marketing: true,
-              policyVersion: "2",
+              policyVersion: "2024-12-03",
             });
           });
         });

--- a/test/cypress/e2e/login.cy.ts
+++ b/test/cypress/e2e/login.cy.ts
@@ -182,7 +182,7 @@ describe("login", () => {
           const c = win.localStorage.getItem("acceptCookieNotice");
           expect(c).to.not.be.null;
           const cookie = JSON.parse(c!);
-          expect(cookie).to.deep.eq({ required: true, functional: true });
+          expect(cookie).to.deep.eq({ required: true, functional: true, marketing: true });
         });
       });
     });


### PR DESCRIPTION
The `hideCookieBanner` command now maintains the `policyVersion`. Cookies can now be removed using `showCookieBanner`.