### PR TITLE
fix(commands): Fixed showCookieBanner and added disableCookieBanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,36 +6,34 @@ Contribute by raising pull requests. All commands must be documented and, if pos
 
 # Content
 <!-- set markdown.extension.toc.levels 2..6 - level 1 is ignored in auto generated toc -->
-- [Cypress commands for Cumulocity](#cypress-commands-for-cumulocity)
-- [Content](#content)
-  - [Overview of commands](#overview-of-commands)
-  - [Screenshot automation](#screenshot-automation)
-  - [Installation and setup](#installation-and-setup)
-    - [Peer dependencies](#peer-dependencies)
-    - [Load plugin](#load-plugin)
-    - [Import commands](#import-commands)
-    - [Environment variables](#environment-variables)
-  - [Additional frameworks](#additional-frameworks)
-  - [Concepts](#concepts)
-    - [Authentication and credentials](#authentication-and-credentials)
-      - [Authentication via getAuth and useAuth commands](#authentication-via-getauth-and-useauth-commands)
-      - [Authentication via test case annotations](#authentication-via-test-case-annotations)
-      - [Authentication via environment variables](#authentication-via-environment-variables)
-      - [Passing authentication to cy.request](#passing-authentication-to-cyrequest)
-    - [Chaining of commands](#chaining-of-commands)
-    - [c8y/client and Web SDK types](#c8yclient-and-web-sdk-types)
-    - [Recording of requests and responses](#recording-of-requests-and-responses)
-    - [Component testing](#component-testing)
-  - [Development](#development)
-    - [Debugging](#debugging)
-      - [Console log debugging](#console-log-debugging)
-      - [Debugging in Visual Studio Code](#debugging-in-visual-studio-code)
-    - [Testing](#testing)
-      - [Test access of DOM elements](#test-access-of-dom-elements)
-      - [Test requests](#test-requests)
-      - [Test interceptions](#test-interceptions)
-  - [Useful links](#useful-links)
-  - [Disclaimer](#disclaimer)
+- [Overview of commands](#overview-of-commands)
+- [Screenshot automation](#screenshot-automation)
+- [Installation and setup](#installation-and-setup)
+  - [Peer dependencies](#peer-dependencies)
+  - [Load plugin](#load-plugin)
+  - [Import commands](#import-commands)
+  - [Environment variables](#environment-variables)
+- [Additional frameworks](#additional-frameworks)
+- [Concepts](#concepts)
+  - [Authentication and credentials](#authentication-and-credentials)
+    - [Authentication via getAuth and useAuth commands](#authentication-via-getauth-and-useauth-commands)
+    - [Authentication via test case annotations](#authentication-via-test-case-annotations)
+    - [Authentication via environment variables](#authentication-via-environment-variables)
+    - [Passing authentication to cy.request](#passing-authentication-to-cyrequest)
+  - [Chaining of commands](#chaining-of-commands)
+  - [c8y/client and Web SDK types](#c8yclient-and-web-sdk-types)
+  - [Recording of requests and responses](#recording-of-requests-and-responses)
+  - [Component testing](#component-testing)
+- [Development](#development)
+  - [Debugging](#debugging)
+    - [Console log debugging](#console-log-debugging)
+    - [Debugging in Visual Studio Code](#debugging-in-visual-studio-code)
+  - [Testing](#testing)
+    - [Test access of DOM elements](#test-access-of-dom-elements)
+    - [Test requests](#test-requests)
+    - [Test interceptions](#test-interceptions)
+- [Useful links](#useful-links)
+- [Disclaimer](#disclaimer)
 
 ## Overview of commands
 
@@ -45,7 +43,7 @@ General commands
 
 - `visitAndWaitForSelector`
 - `setLanguage`
-- `hideCookieBanner`, `acceptCookieBanner`, `showCookieBanner`
+- `acceptCookieBanner`, `showCookieBanner`, `disableCookieBanner`
 - `disableGainsight`
 
 Authentication related commands

--- a/src/lib/commands/general.ts
+++ b/src/lib/commands/general.ts
@@ -6,18 +6,35 @@ declare global {
   namespace Cypress {
     interface Chainable {
       /**
-       * Disables the Cumulocity cookie banner.
+       * Hides the Cumulocity cookie banner by accepting all cookies. See `acceptCookieBanner`.
+       * @deprecated Use `acceptCookieBanner` instead.
        */
       hideCookieBanner(): Chainable<void>;
 
       /**
        * Accept the cookie banner with the provided configuration for current, functional and marketing cookies.
+       * As the cookie banner requires the cookie set to match the current policy version, accepting the cookie
+       * banner adds an interception for the public options to get the current policy version. Make sure to call
+       * this command before visiting the page. `cy.login` will call this command automatically with the
+       * default values. If the cookie banner has been accepted or hidden using `acceptCookieBanner` or `hideCookieBanner`,
+       * you can reset it by calling `showCookieBanner`.
+       *
+       * To fully disable the cookie banner, you can use `cy.disableCookieBanner`. This will not set the required
+       * cookies, but instead disable the cookie banner completely.
        */
       acceptCookieBanner(
         required: boolean,
         functional: boolean,
         marketing: boolean
       ): Chainable<void>;
+
+      /**
+       * Disables the cookie banner without setting any cookies. This will disable the cookie banner completely.
+       * Use if you want to disable the cookie banner for all policy versions. See `acceptCookieBanner` for more
+       * information.
+       * @see acceptCookieBanner
+       */
+      disableCookieBanner(): Chainable<void>;
 
       /**
        * Ensure the cookie banner is shown on visit. If the cookie banner has been
@@ -96,6 +113,7 @@ Cypress.Commands.add(
 
     const setLocalCookie = (c: { [key: string]: string | boolean }) => {
       const cookie = JSON.stringify(c);
+      window.localStorage.removeItem("__ccHideCookieBanner");
       Cypress.on("window:before:load", (window) => {
         window.localStorage.setItem(COOKIE_NAME, cookie);
       });
@@ -113,6 +131,10 @@ Cypress.Commands.add(
           if (response.statusCode !== 200) {
             return;
           }
+          if (window.localStorage.getItem("__ccHideCookieBanner") === "false") {
+            return;
+          }
+
           const policyVersion = response.body.cookieBanner?.policyVersion;
           const denyCookies: { [key: string]: string | boolean } = {
             required: !!required,
@@ -125,7 +147,7 @@ Cypress.Commands.add(
           setLocalCookie(denyCookies);
         });
       }
-    ).as("publicOptions");
+    );
   }
 );
 
@@ -133,10 +155,31 @@ Cypress.Commands.add("showCookieBanner", () => {
   Cypress.log({
     name: "showCookieBanner",
   });
+
   Cypress.on("window:before:load", (window) => {
     window.localStorage.removeItem("acceptCookieNotice");
   });
   window.localStorage.removeItem("acceptCookieNotice");
+  window.localStorage.setItem("__ccHideCookieBanner", "false");
+});
+
+Cypress.Commands.add("disableCookieBanner", () => {
+  Cypress.log({
+    name: "disableCookieBanner",
+    message: "",
+  });
+
+  cy.intercept(
+    {
+      pathname: /\/apps\/public\/public-options(@app-[^/]+)?\/options.json/,
+    },
+    (req) => {
+      req.continue((res) => {
+        res.body.cookieBanner = undefined;
+        res.send();
+      });
+    }
+  );
 });
 
 Cypress.Commands.add(

--- a/test/cypress/e2e/general.cy.ts
+++ b/test/cypress/e2e/general.cy.ts
@@ -110,6 +110,23 @@ describe("general", () => {
         });
       });
     });
+
+    it("disableCookieBanner should remove cookieBanner", () => {
+      cy.disableCookieBanner()
+        .as("interception")
+        .then(() =>
+          $.get(url(`/apps/public/public-options@app-cockpit/options.json?_=c`))
+        )
+        .then((response) => {
+          expect(response.cookieBanner).to.be.undefined;
+          expect(response.cookiePreferences).to.not.be.undefined;
+          cy.window().then((win) => {
+            const cookie = win.localStorage.getItem("acceptCookieNotice");
+            expect(cookie).to.be.null;
+          });
+        })
+        .wait("@interception");
+    });
   });
 
   context("setLanguage", () => {


### PR DESCRIPTION
The `cy.showCookieBanner` command did remove the accepted cookie from the session, but the public options request was still intercepted and would set a new cookie. With this fix, the interception will not set a new cookie. To address possible issues with `policyVersion` now required to match for the cookie banner to not show, the `cy.disableCookieBanner` command has been introduced. By disabling the cookie banner, Cumulocity will not check cookie and policy versions.