### PR TITLE
fix(build): Fixed package bin paths (#217)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,31 @@ jobs:
       - name: Run build
         run: npm run build
 
+      - name: Validate and test bin paths
+        run: |
+          # Extract bin paths from package.json
+          BIN_PATHS=$(jq -r '.bin[]' package.json)
+          
+          cd dist/
+          
+          # Check if each bin path exists and is executable
+          for BIN_PATH in $BIN_PATHS; do
+            if [ ! -f "$BIN_PATH" ]; then
+              echo "Bin path $BIN_PATH does not exist."
+              exit 1
+            fi
+            if [ ! -x "$BIN_PATH" ]; then
+              echo "Bin path $BIN_PATH is not executable."
+              exit 1
+            fi
+          done
+
+          # Test the --version command for each bin path
+          for BIN_PATH in $BIN_PATHS; do
+            VERSION_OUTPUT=$(node $BIN_PATH --version)
+            echo "$BIN_PATH version: $VERSION_OUTPUT"
+            if [[ ! "$VERSION_OUTPUT" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Invalid version output for $BIN_PATH: $VERSION_OUTPUT"
+              exit 1
+            fi
+          done

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       },
       "bin": {
         "c8yctrl": "c8yctrl/c8yctrl.js",
-        "c8yscrn": "c8yscrn/startup.js"
+        "c8yscrn": "c8yscrn/c8yscrn.js"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "jest:run": "jest --config jest.config.mjs",
     "clean": "rimraf dist/ && rimraf 'packages/**/dist/' && rimraf 'packages/**/.yalc' && rimraf 'packages/pactrunner/yalc.lock'",
     "copy-files": "copyfiles --up 1 -V './src/**/*.js' './src/**/*.d.ts' dist/ && copyfiles '*.md' package.json dist/",
-    "build": "npm run clean && npm run screenshot:schema && npm run copy-files && tsc -b -v src/ && npm run build:plugin",
+    "build": "npm run clean && npm run screenshot:schema && npm run copy-files && tsc -b -v src/ && npm run build:plugin && npm run prepare:c8yctrl && npm run prepare:c8yscrn",
     "build:plugin": "rollup -c rollup.config.mjs",
-    "package": "npm run build && npm run clean:package:folder && npm run clean:package:c8yctrl && npm run clean:package:c8yscrn && cd dist/ && npm run clean:package:json",
+    "package": "npm run build && npm run clean:package:folder && cd dist/ && npm run clean:package:json",
     "yalc:runner": "npm run yalc:publish && cd packages/pactrunner && yalc add cumulocity-cypress",
     "yalc:publish": "npm run clean && npm run package && cd dist/ && yalc publish && cd ..",
-    "clean:package:c8yctrl": "mv dist/c8yctrl/startup.js dist/c8yctrl/c8yctrl.js && rm -f dist/c8yctrl/*.config.js",
-    "clean:package:c8yscrn": "mv dist/c8yscrn/startup.js dist/c8yscrn/c8yscrn.js",
+    "prepare:c8yctrl": "mv dist/c8yctrl/startup.js dist/c8yctrl/c8yctrl.js && rm -f dist/c8yctrl/*.config.js",
+    "prepare:c8yscrn": "mv dist/c8yscrn/startup.js dist/c8yscrn/c8yscrn.js",
     "clean:package:folder": "rimraf -v -g './dist/**/*.tsbuildinfo'",
     "clean:package:json": "npm pkg delete 'devDependencies' && npm pkg delete 'scripts'",
     "lint": "eslint ./",
@@ -45,7 +45,7 @@
   },
   "bin": {
     "c8yctrl": "./c8yctrl/c8yctrl.js",
-    "c8yscrn": "./c8yscrn/startup.js"
+    "c8yscrn": "./c8yscrn/c8yscrn.js"
   },
   "workspaces": [
     "packages/*"
@@ -71,6 +71,7 @@
       "types": "./c8yctrl/c8yctrl.d.ts",
       "default": "./c8yctrl/c8yctrl.js"
     },
+    "./shared/*": "./shared/*",
     "./commands/*": "./lib/commands/*"
   },
   "typesVersions": {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -36,7 +36,7 @@ export default [
     plugins: [dts()],
   },
   {
-    input: glob.sync('./dist/c8yscrn/*.js'),
+    input: glob.sync('./dist/c8yctrl/*.js'),
     output: [
       {
         name: "c8yctrl",
@@ -54,7 +54,7 @@ export default [
       shebang(
         {
           include: [
-            "dist/c8yscrn/startup.js",
+            "dist/c8yctrl/startup.js",
           ]
         }
       )

--- a/src/c8yscrn/cypress/config.js
+++ b/src/c8yscrn/cypress/config.js
@@ -1,6 +1,6 @@
 // use javascript instead of typescript to avoid typescript compilation
 const { defineConfig } = require("cypress");
-const { configureC8yScreenshotPlugin } = require("../../../plugin");
+const { configureC8yScreenshotPlugin } = require("../../plugin");
 
 module.exports = defineConfig({
   e2e: {


### PR DESCRIPTION
There has been an issue packaging `c8yscrn` and `c8yctrl` into the required bin locations. This has been fixed.