### PR TITLE
fix(c8yscrn): Fixed multistep form support for type action

### DIFF
--- a/src/c8yscrn/runner.ts
+++ b/src/c8yscrn/runner.ts
@@ -279,18 +279,27 @@ export class C8yScreenshotRunner {
         cy.get(selector).clear();
       }
       cy.get(selector).type(action.value);
-    } else if (_.isArrayLike(action.value)) {
-      const values = _.isArray(action.value) ? action.value : [action.value];
+    } else if (_.isArray(action.value)) {
+      const values: (string | null)[][] = _.isArray(action.value)
+        ? _.isArray(action.value[0])
+          ? (action.value as string[][])
+          : [action.value as string[]]
+        : [[action.value]];
+
       values.forEach((formInput) => {
         cy.get(selector).within(($withElement) => {
-          const $elements = Cypress.$($withElement).find("input[type=text]");
+          const $elements = Cypress.$($withElement).find(
+            "input[type=text], textarea"
+          );
           const length = Math.min($elements.length, formInput.length);
-          (formInput as string[]).forEach((value: string, index: number) => {
+          formInput.forEach((value, index) => {
             if (index >= length) return;
+            if (value != null && value !== "") {
             if (action.clear === true) {
-              cy.get(selector).clear();
+                cy.wrap($elements[index]).clear();
+              }
+              cy.wrap($elements[index]).type(value);
             }
-            cy.get("input[type=text]").eq(index).type(value);
           });
         });
         cy.then(() => {

--- a/src/c8yscrn/schema.json
+++ b/src/c8yscrn/schema.json
@@ -527,14 +527,20 @@
                                     "anyOf": [
                                         {
                                             "items": {
-                                                "type": "string"
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
                                             },
                                             "type": "array"
                                         },
                                         {
                                             "items": {
                                                 "items": {
-                                                    "type": "string"
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
                                                 },
                                                 "type": "array"
                                             },
@@ -616,14 +622,20 @@
                                     "anyOf": [
                                         {
                                             "items": {
-                                                "type": "string"
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
                                             },
                                             "type": "array"
                                         },
                                         {
                                             "items": {
                                                 "items": {
-                                                    "type": "string"
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
                                                 },
                                                 "type": "array"
                                             },

--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -244,7 +244,7 @@ export interface TypeAction {
    * 
    * For multistep forms, the value can be an array of strings. Each array represents a step in the form. The first value in the array is typed into the first textfield, the second value in the second textfield, and so on. Configure submit selector to continue to the next step of the form.
    */
-  value: string | string[] | string[][];
+  value: string | (string | null)[] | (string | null)[][];
   /**
    * If true, the text input is cleared before typing. The default is false.
    * @default false


### PR DESCRIPTION
The `type` action multistep support using arrays as `value` has been fixed. It now supports `null` within the array to skip an entry and uses `input[type=text]` as well as `textarea`.