### PR TITLE
fix(c8yscrn): Pass all auth env variables from environment

### DIFF
--- a/src/shared/util.spec.ts
+++ b/src/shared/util.spec.ts
@@ -1,0 +1,43 @@
+import { sanitizeStringifiedObject } from "./util";
+
+describe("util", () => {
+  it("sanitizeStringifiedObject", () => {
+    expect(sanitizeStringifiedObject({ test: "test" } as any)).toEqual({
+      test: "test",
+    });
+    expect(sanitizeStringifiedObject("test")).toEqual("test");
+    expect(sanitizeStringifiedObject(undefined as any)).toEqual(undefined);
+
+    expect(
+      sanitizeStringifiedObject('{ "password": "abcdefg", "test": "test" }')
+    ).toEqual('{ "password": "***", "test": "test" }');
+
+    expect(sanitizeStringifiedObject('{ "password": "abcdefg" }')).toEqual(
+      '{ "password": "***" }'
+    );
+
+    expect(sanitizeStringifiedObject('{ "password": "abcdefg" }')).toEqual(
+      '{ "password": "***" }'
+    );
+
+    expect(sanitizeStringifiedObject('{"password": "abcdefg"}')).toEqual(
+      '{"password": "***"}'
+    );
+
+    expect(sanitizeStringifiedObject("{password: abcdefg}")).toEqual(
+      "{password: ***}"
+    );
+
+    expect(
+      sanitizeStringifiedObject("{username: myuser, password: abc123}")
+    ).toEqual("{username: myuser, password: ***}");
+
+    expect(
+      sanitizeStringifiedObject("{username: myuser, password: abc123}")
+    ).toEqual("{username: myuser, password: ***}");
+
+    expect(
+      sanitizeStringifiedObject("{ password: abc123, username: myuser }")
+    ).toEqual("{ password: ***, username: myuser }");
+  });
+});

--- a/src/shared/util.ts
+++ b/src/shared/util.ts
@@ -40,3 +40,13 @@ export function getPackageVersion() {
   }
   return "unknown";
 }
+
+export function sanitizeStringifiedObject(value: string) {
+  if (!value || typeof value !== "string") {
+    return value;
+  }
+  return value.replace(
+    /("?)(password)("?):\s+("?).*?(")?(\s*,?[\s\n}]+)/gi,
+    '$1$2$3: $4***$5$6'
+  );
+}


### PR DESCRIPTION
All env variables starting with `C8Y_` or ending with `_username` or `_password` are now passed from the environment into the screenshot workflows. Use `DEBUG=c8y:scrn:env` for logging what is passed.