### PR TITLE
fix(c8yscrn): Add failure screenshot config options

### DIFF
--- a/doc/Screenshot Automation.md
+++ b/doc/Screenshot Automation.md
@@ -117,16 +117,20 @@ c8yscrn run
 Run workflows in headless mode
 
 Options:
-  -c, --config      The yaml config file                   [string] [default: "c8yscrn.config.yaml"]
-  -f, --folder      The target folder for the screenshots                                   [string]
-  -u, --baseUrl     The Cumulocity base url                                                 [string]
-      --clear       Clear the target folder and remove all data           [boolean] [default: false]
-  -b, --browser     Browser to use                                      [string] [default: "chrome"]
-      --diff        Enable image diffing                                  [boolean] [default: false]
-      --diffFolder  Optional target folder for the diff images                              [string]
-      --diffSkip    Skip screenshots without difference                    [boolean] [default: true]
-  -h, --highlight   Enable or disable highlights in screenshots            [boolean] [default: true]
-  -t, --tags        Run only screenshot workflows with the given tags                        [array]
+      --version        Show version number                                                 [boolean]
+      --help           Show help                                                           [boolean]
+  -c, --config         The yaml config file                [string] [default: "c8yscrn.config.yaml"]
+  -u, --baseUrl        The Cumulocity base url                                              [string]
+  -f, --folder         The target folder for the screenshots                                [string]
+  -e, --failureFolder  The target folder for failure screenshots                            [string]
+      --skipFailure    Disable failure screenshots                        [boolean] [default: false]
+      --clear          Clear the target folder and remove all data        [boolean] [default: false]
+  -b, --browser        Browser to use                                   [string] [default: "chrome"]
+      --diff           Enable image diffing                               [boolean] [default: false]
+      --diffFolder     Optional target folder for the diff images                           [string]
+      --diffSkip       Skip screenshots without difference                 [boolean] [default: true]
+  -h, --highlight      Enable or disable highlights in screenshots         [boolean] [default: true]
+  -t, --tags           Run only screenshot workflows with the given tags                     [array]
 ```
 
 When using `open` instead of `run`, the Cypress test runner will open in Cypress application. This can be useful for debugging and developing new screenshot workflows.

--- a/src/c8yscrn/helper.ts
+++ b/src/c8yscrn/helper.ts
@@ -119,6 +119,7 @@ export function resolveConfigOptions(args: Partial<C8yScreenshotOptions>): any {
     config: {
       e2e: {
         baseUrl,
+        screenshotOnRunFailure: !(args.skipFailure ?? false),
         screenshotsFolder,
         trashAssetsBeforeRuns: args.clear ?? false,
         spec: path.join(cypressFolder, "screenshots.cy.js"),

--- a/src/c8yscrn/startup.ts
+++ b/src/c8yscrn/startup.ts
@@ -233,6 +233,12 @@ function runOptions(yargs: Argv) {
       requiresArg: true,
       description: "The target folder for failure screenshots",
     })
+    .option("skipFailure", {
+      type: "boolean",
+      requiresArg: false,
+      description: "Disable failure screenshots",
+      default: false,
+    })
     .option("clear", {
       type: "boolean",
       requiresArg: false,

--- a/src/c8yscrn/startup.ts
+++ b/src/c8yscrn/startup.ts
@@ -57,7 +57,7 @@ const logEnv = debug("c8y:scrn:env");
 
     const tags = (args.tags ?? []).join(",");
     log(`Running with tags: ${tags}`);
-    
+
     const envs = {
       ...(dotenv().parsed ?? {}),
       ...(dotenv({ path: ".c8yscrn" }).parsed ?? {}),
@@ -107,6 +107,11 @@ const logEnv = debug("c8y:scrn:env");
         ? resolveScreenshotFolder(args.diffFolder)
         : undefined;
 
+    const failureFolder =
+      args.failureFolder != null
+        ? resolveScreenshotFolder(args.failureFolder)
+        : undefined;
+
     let diffOptions: (DiffOptions & ODiffOptions) | undefined = undefined;
     if (args.diff === true) {
       diffOptions = {
@@ -134,6 +139,7 @@ const logEnv = debug("c8y:scrn:env");
             _c8yscrnyaml: configData,
             _c8yscrnBrowserLaunchArgs: browserLaunchArgs,
             _c8yscrnDiffOptions: diffOptions,
+            _c8yscrnFailureFolder: failureFolder,
           },
         },
       },
@@ -220,6 +226,12 @@ function runOptions(yargs: Argv) {
       type: "string",
       requiresArg: true,
       description: "The target folder for the screenshots",
+    })
+    .option("failureFolder", {
+      alias: "e",
+      type: "string",
+      requiresArg: true,
+      description: "The target folder for failure screenshots",
     })
     .option("clear", {
       type: "boolean",

--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -419,6 +419,7 @@ export interface C8yScreenshotOptions {
   config: string;
   folder: string;
   failureFolder: string;
+  skipFailure: boolean;
   open: boolean;
   browser: "chrome" | "firefox" | "electron";
   browserLaunchArgs: string;

--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -418,6 +418,7 @@ export interface C8yScreenshotOptions {
   baseUrl: string;
   config: string;
   folder: string;
+  failureFolder: string;
   open: boolean;
   browser: "chrome" | "firefox" | "electron";
   browserLaunchArgs: string;


### PR DESCRIPTION
For failing workflows, the target folder for failure screenshots can now be configured using the `failureFolder` command line argument. To disable screenshots on failure, use the `skipFailure` argument.