### PR TITLE
Discard the original screenshot if there is no difference in the screenshots

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -354,6 +354,15 @@ export function configureC8yScreenshotPlugin(
         });
       };
 
+      const deleteFile = (source: string) => {
+        fs.unlink(source, (err) => {
+          if (err) {
+            logScreenshot(`Error deleting file: ${err}`);
+            return reject(err);
+          }
+          logScreenshot(`Deleted ${source}`);
+        });
+      }
       // path contains spec name, remove it. might only be required for run() mode however
       const newPath =
         details.specName.trim() == ""
@@ -421,6 +430,9 @@ export function configureC8yScreenshotPlugin(
               logScreenshot(
                 `Skipping ${screenshotFile} (skipMove: ${diffOptions.skipMove})`
               );
+              // discard the screenshot if there is a match and skipMove is false
+              if(!diffOptions.skipMove)
+                deleteFile(details.path);
             } else {
               moveFile(details.path, screenshotFile);
             }


### PR DESCRIPTION
Previously, when diff is enabled and there is not difference in the screenshots, the file wasn't moved to the output folder which led to images being present under `screenshots.cy.js/dtm/..` folder in the `c8y-docs` repository. 
This update discards the screenshot unless the diff option skipMove is set to true