### PR TITLE
fix: Fixed lib/* exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ module.exports = defineConfig({
 To use the `cumulocity-cypress` commands in your Cypress tests, import the commands in  your projects `e2e.supportFile` (e.g. `cypress/support/e2e.ts`).
 
 ```typescript
-import "cumulocity-cypress/lib/commands";
+import "cumulocity-cypress/commands";
 ```
 
 This will import the standard commands, including for example login, authentication, date conversion, administration. 
@@ -135,11 +135,11 @@ Optional commands for import (only import if really needed):
 
 ```typescript
 // Import extension for cy.request() to support authentication
-import "cumulocity-cypress/lib/commands/request";
+import "cumulocity-cypress/commands/request";
 // Import commands for recording and mocking of requests and responses
-import "cumulocity-cypress/lib/commands/c8ypact";
+import "cumulocity-cypress/commands/c8ypact";
 // Enable recording and mocking for cy.intercept()
-import "cumulocity-cypress/lib/commands/intercept";
+import "cumulocity-cypress/commands/intercept";
 ```
 
 See [API and Integration Testing](./doc/API%20and%20Integration%20Testing.md) for more information on how to enable recording and matching of requests and responses using `cy.c8yclient` and `cy.intercept`.
@@ -147,7 +147,7 @@ See [API and Integration Testing](./doc/API%20and%20Integration%20Testing.md) fo
 Import the `mount` command for component testing of Cumulocity Angular components.
 
 ```typescript
-import "cumulocity-cypress/lib/commands/mount";
+import "cumulocity-cypress/commands/mount";
 ```
 
 ### Environment variables
@@ -286,7 +286,7 @@ Cypress.env("C8Y_PASSWORD", "password");
 
 #### Passing authentication to cy.request
 
-With `import "cumulocity-cypress/lib/commands/request"`, it is also possible to add authentication support to `cy.request()` command. If enabled, `cy.request()` will use authentication from environment, `useAuth()` and test case auth annotation. As this feature is considered experimental, it is not automatically imported.
+With `import "cumulocity-cypress/commands/request"`, it is also possible to add authentication support to `cy.request()` command. If enabled, `cy.request()` will use authentication from environment, `useAuth()` and test case auth annotation. As this feature is considered experimental, it is not automatically imported.
 
 Note: chaining authentication into `cy.request()` is not supported as `cy.request()` does not support previous subject and always is a parent in the Cypress chain.
 

--- a/package.json
+++ b/package.json
@@ -71,8 +71,14 @@
       "types": "./c8yctrl/index.d.ts",
       "default": "./c8yctrl/index.js"
     },
+    "./contrib": {
+      "types": "./src/contrib/index.d.ts",
+      "default": "./src/contrib/index.js"
+    },
     "./shared/*": "./shared/*",
-    "./commands/*": "./lib/commands/*"
+    "./commands/*": "./lib/commands/*",
+    "./contrib/*": "./src/contrib/*",
+    "./lib/*": "./lib/*"
   },
   "typesVersions": {
     "*": {
@@ -90,6 +96,12 @@
       ],
       "commands/*": [
         "./lib/commands/*.d.ts"
+      ],
+      "lib/*": [
+        "./lib/*"
+      ],
+      "contrib/*": [
+        "./src/contrib/*"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -72,12 +72,12 @@
       "default": "./c8yctrl/index.js"
     },
     "./contrib": {
-      "types": "./src/contrib/index.d.ts",
-      "default": "./src/contrib/index.js"
+      "types": "./contrib/index.d.ts",
+      "default": "./contrib/index.js"
     },
     "./shared/*": "./shared/*",
     "./commands/*": "./lib/commands/*",
-    "./contrib/*": "./src/contrib/*",
+    "./contrib/*": "./contrib/*",
     "./lib/*": "./lib/*"
   },
   "typesVersions": {
@@ -101,7 +101,7 @@
         "./lib/*"
       ],
       "contrib/*": [
-        "./src/contrib/*"
+        "./contrib/*"
       ]
     }
   },


### PR DESCRIPTION
Imports from `cumulocity-cypress/lib/*` have been fixed. The documentation has been updated with the current import paths. Refactoring and reorganisation in 0.8.x has been updated to enable backward compatibility with imports from `*/lib/*`.