### PR TITLE
fix(c8yctrl): Updated env variables to use C8YCTRL prefix

### DIFF
--- a/doc/Screenshot Automation.md
+++ b/doc/Screenshot Automation.md
@@ -462,7 +462,7 @@ screenshots: array
 
 **baseUrl**
 - **Type**: string
-- **Description**: The base URL used for all relative requests in your screenshot workflows. This value can be also passed and overwritten using the `--baseUrl` command-line option or the `C8Y_BASE_URL` env variable.
+- **Description**: The base URL used for all relative requests in your screenshot workflows. This value can be also passed and overwritten using the `--baseUrl` command-line option or the `C8Y_BASEURL` env variable.
 - **Example**: `https://your-cumulocity-tenant.com`
 
 **title**

--- a/src/c8yscrn/runner.ts
+++ b/src/c8yscrn/runner.ts
@@ -130,7 +130,7 @@ export class C8yScreenshotRunner {
 
       beforeEach(() => {
         Cypress.session.clearAllSavedSessions();
-        if (Cypress.env("C8Y_CTRL_MODE") != null) {
+        if (Cypress.env("C8YCTRL_MODE") != null) {
           cy.wrap(c8yctrl(), { log: false });
         }
       });
@@ -535,7 +535,7 @@ function debug(message: string, options?: any) {
 }
 
 export function isRecording(): boolean {
-  return Cypress.env("C8Y_CTRL_MODE") === "recording";
+  return Cypress.env("C8YCTRL_MODE") === "recording" || Cypress.env("C8YCTRL_MODE") === "record";
 }
 
 export function isClickAction(action: Action): boolean {


### PR DESCRIPTION
Now using `C8YCTRL` as prefix for all env variables. Most of old env variables are still supported for backward compatibility. It is however required to update the env variables to prepare for future changes. A list of all env variables can be found in the [documentation](https://github.com/Cumulocity-IoT/cumulocity-cypress/blob/develop/doc/Proxy%20based%20Testing.md#environment-variables).