### PR TITLE
fix(pactrunner): Improved authorization type detection in pactrunner

### DIFF
--- a/packages/pact-runner/cypress/support/e2e.ts
+++ b/packages/pact-runner/cypress/support/e2e.ts
@@ -1,9 +1,3 @@
-import "cumulocity-cypress/lib/commands/";
+import "cumulocity-cypress/commands";
+import "cumulocity-cypress/commands/oauthlogin";
 import "cumulocity-cypress/c8ypact";
-import "cumulocity-cypress/lib/commands/oauthlogin";
-
-before(() => {
-  // cache tenant id in C8Y_TENANT
-  cy.getAuth("admin").getTenantId({ ignorePact: true });
-  cy.getAuth("admin").getSystemVersion({ ignorePact: true });
-});

--- a/src/lib/pact/runner.ts
+++ b/src/lib/pact/runner.ts
@@ -1,5 +1,5 @@
 import { C8yBaseUrl, C8yTenant } from "../../shared/types";
-import { C8yClientOptions } from "../../shared/c8yclient";
+import { C8yAuthOptions, C8yClientOptions } from "../../shared/c8yclient";
 import {
   C8yPact,
   C8yPactInfo,
@@ -7,6 +7,8 @@ import {
   isPact,
 } from "../../shared/c8ypact";
 import { getBaseUrlFromEnv } from "../utils";
+import { Client } from "@c8y/client";
+
 const { _ } = Cypress;
 
 /**
@@ -118,6 +120,11 @@ export class C8yDefaultPactRunner implements C8yPactRunner {
     keys.forEach((key: string) => {
       const subTree = hierarchy[key];
       if (isPact(subTree)) {
+        beforeEach(() => {
+          if (!Cypress.env("C8Y_TENANT")) {
+            cy.getAuth().getTenantId({ ignorePact: true });
+          }
+        });
         it(key, () => {
           this.runTest(subTree);
         });
@@ -133,6 +140,7 @@ export class C8yDefaultPactRunner implements C8yPactRunner {
   runTest(pact: C8yPact) {
     Cypress.c8ypact.current = pact;
     this.idMapper = {};
+    let currentAuth: C8yAuthOptions | undefined = undefined;
 
     for (const record of pact?.records || []) {
       cy.then(() => {
@@ -140,7 +148,18 @@ export class C8yDefaultPactRunner implements C8yPactRunner {
           pact.info?.strictMatching != null ? pact.info.strictMatching : true;
 
         const url = this.createURL(record, pact.info);
+        if (!url) {
+          cy.log("Skipping request without URL.");
+          return;
+        }
         const clientFetchOptions = this.createFetchOptions(record, pact.info);
+
+        if (clientFetchOptions.method.toLowerCase() === "post") {
+          if (!clientFetchOptions.body) {
+            cy.log("Skipping POST request without body: " + url);
+            return;
+          }
+        }
 
         let user = record.auth?.userAlias || record.auth?.user;
         if ((user || "").split("/").length > 1) {
@@ -179,21 +198,30 @@ export class C8yDefaultPactRunner implements C8yPactRunner {
           }
         };
 
-        if (record.auth && record.auth.type === "CookieAuth") {
-          if (user) {
-            cy.getAuth(user).login();
+        const envAuth = Cypress.env("C8Y_PACT_RUNNER_AUTH");
+
+        const isCookieAuth =
+          (envAuth ?? record.authType()) === "CookieAuth" &&
+          envAuth !== "BasicAuth";
+
+        const isBasicAuth = (envAuth ?? record.authType()) === "BasicAuth";
+        const f = (c: Client) => c.core.fetch(url, clientFetchOptions);
+
+        (user ? cy.getAuth(user) : cy.getAuth()).then((auth) => {
+          if (user !== "devicebootstrap" && isCookieAuth) {
+            if (currentAuth == null || auth?.user !== currentAuth?.user) {
+              cy.wrap(auth).login();
+              currentAuth = auth;
+            }
+            cy.c8yclient(f, cOpts).then(responseFn);
+          } else {
+            if (isBasicAuth) {
+              cy.wrap(auth).c8yclient(f, cOpts).then(responseFn);
+            } else {
+              cy.c8yclient(f, cOpts).then(responseFn);
+            }
           }
-          if (url) {
-            cy.c8yclient(
-              (c) => c.core.fetch(url, clientFetchOptions),
-              cOpts
-            ).then(responseFn);
-          }
-        } else if (user && url) {
-          cy.getAuth(user)
-            .c8yclient((c) => c.core.fetch(url, clientFetchOptions), cOpts)
-            .then(responseFn);
-        }
+        });
       });
     }
   }
@@ -201,7 +229,9 @@ export class C8yDefaultPactRunner implements C8yPactRunner {
   protected createHeader(pact: C8yPactRecord): any {
     const headers = _.omit(pact.request.headers || {}, [
       "X-XSRF-TOKEN",
+      "x-xsrf-token",
       "Authorization",
+      "authorization",
     ]);
     return headers;
   }
@@ -248,7 +278,10 @@ export class C8yDefaultPactRunner implements C8yPactRunner {
     if (!value || !info) return value;
     let result = value;
 
-    const tenantUrl = (baseUrl: C8yBaseUrl, tenant?: C8yTenant): URL | undefined => {
+    const tenantUrl = (
+      baseUrl: C8yBaseUrl,
+      tenant?: C8yTenant
+    ): URL | undefined => {
       if (!baseUrl || !tenant) return undefined;
       try {
         const url = new URL(baseUrl);

--- a/src/lib/pact/runner.ts
+++ b/src/lib/pact/runner.ts
@@ -52,6 +52,9 @@ type TestHierarchyTree<T> = { [key: string]: T | TestHierarchyTree<T> };
  * Default implementation of C8yPactRunner. Runtime for C8yPact objects that will
  * create the tests dynamically and rerun recorded requests. Supports Basic and Cookie based
  * authentication, id mapping, consumer and producer filtering and URL replacement.
+ * 
+ * Use `C8Y_PACT_RUNNER_AUTH` to set the authentication type for the runner and overwrite
+ * the authentication type detected in the pact records. Supported values are `CookieAuth` and `BasicAuth`.
  */
 export class C8yDefaultPactRunner implements C8yPactRunner {
   constructor() {}

--- a/src/shared/c8ypact/c8ydefaultpact.spec.ts
+++ b/src/shared/c8ypact/c8ydefaultpact.spec.ts
@@ -49,7 +49,7 @@ const url = (path: string, baseUrl: C8yBaseUrl = BASE_URL) => {
 };
 
 // more tests of still in c8ypact.cy.ts
-describe("c8defaultpact", () => {
+describe("c8ydefaultpact", () => {
   // response to create a test pact object
   const response: Cypress.Response<any> = {
     status: 200,

--- a/src/shared/c8ypact/c8ydefaultpactrecord.spec.ts
+++ b/src/shared/c8ypact/c8ydefaultpactrecord.spec.ts
@@ -1,0 +1,190 @@
+/// <reference types="jest" />
+
+import _ from "lodash";
+
+import { C8yDefaultPact } from "./c8ydefaultpact";
+import { isPact } from "./c8ypact";
+import { C8yDefaultPactRecord } from "./c8ydefaultpactrecord";
+import { C8yBaseUrl } from "../types";
+
+const BASE_URL = "http://localhost:4200";
+const url = (path: string, baseUrl: C8yBaseUrl = BASE_URL) => {
+  if (baseUrl && !baseUrl.toLowerCase().startsWith("http")) {
+    baseUrl = `https://${baseUrl}`;
+  }
+  return `${baseUrl}${path}`;
+};
+
+// more tests of still in c8ypact.cy.ts
+describe("c8ydefaultpactrecord", () => {
+  // response to create a test pact object
+  const response: Cypress.Response<any> = {
+    status: 200,
+    statusText: "OK",
+    headers: { "content-type": "application/json" },
+    body: { name: "t123456789" },
+    duration: 100,
+    requestHeaders: { "content-type": "application/json2" },
+    requestBody: { id: "abc123124" },
+    allRequestResponses: [],
+    isOkStatusCode: false,
+    method: "PUT",
+    url: BASE_URL,
+  };
+
+  describe("create record", function () {
+    let record: C8yDefaultPactRecord | undefined;
+
+    beforeEach(() => {
+      record = new C8yDefaultPactRecord(
+        {
+          url: "http://localhost:8080/inventory/managedObjects/1?withChildren=false",
+        },
+        {
+          status: 201,
+          isOkStatusCode: true,
+        },
+        {
+          baseUrl: "http://localhost:8080",
+        },
+        { user: "test" }
+      );
+    });
+
+    it("should create C8yDefaultPactRecord", function () {
+      expect(record).not.toBeNull();
+      expect(record!.request).not.toBeNull();
+      expect(record!.response).not.toBeNull();
+      expect(record!.auth).not.toBeNull();
+      expect(record!.options).not.toBeNull();
+    });
+  });
+
+  describe("hasRequestHeader", function () {
+    let record: C8yDefaultPactRecord | undefined;
+
+    beforeEach(() => {
+      record = new C8yDefaultPactRecord(
+        {
+          url: "http://localhost:8080/inventory/managedObjects/1?withChildren=false",
+          headers: { "x-xsrf-token": "abcde" },
+        },
+        {
+          status: 201,
+          isOkStatusCode: true,
+        },
+        {},
+        { user: "test" }
+      );
+    });
+
+    it("should return true for existing header", function () {
+      expect(record!.hasRequestHeader("x-xsrf-token")).toBeTruthy();
+    });
+
+    it("should return false for non-existing header", function () {
+      expect(record!.hasRequestHeader("content-type2")).toBeFalsy();
+    });
+
+    it("should use case-insensitive comparison", function () {
+      expect(record!.hasRequestHeader("X-XSRF-TOKEN")).toBeTruthy();
+    });
+  });
+
+  describe("authType", function () {
+    let record: C8yDefaultPactRecord | undefined;
+
+    beforeEach(() => {
+      record = new C8yDefaultPactRecord(
+        {
+          url: "http://localhost:8080/inventory/managedObjects/1?withChildren=false",
+          headers: { "x-xsrf-token": "abcde" },
+        },
+        {
+          status: 201,
+          isOkStatusCode: true,
+        },
+        {},
+        { user: "test" }
+      );
+    });
+
+    it("should return CookieAuth for x-xsrf-token header", function () {
+      expect(record!.authType()).toBe("CookieAuth");
+    });
+
+    it("should return type from auth object", function () {
+      record!.auth = { type: "BasicAuth", user: "test" };
+      expect(record!.authType()).toBe("BasicAuth");
+    });
+
+    it("should return undefined for unknown auth type", function () {
+      record!.request.headers = {};
+      record!.auth = { type: "UnknownAuth", user: "test" };
+      expect(record!.authType()).toBe(undefined);
+    });
+
+    it("should return BasicAuth for Authorization header", function () {
+      record!.request.headers = { Authorization: "Basic abcde" };
+      expect(record!.authType()).toBe("BasicAuth");
+    });
+  });
+
+  describe("date", function () {
+    let record: C8yDefaultPactRecord | undefined;
+    beforeEach(() => {
+      record = new C8yDefaultPactRecord(
+        {
+          url: "http://localhost:8080/inventory/managedObjects/1?withChildren=false",
+        },
+        {
+          status: 201,
+          isOkStatusCode: true,
+        }
+      );
+    });
+
+    it("should return date object", function () {
+      record!.response.headers = { date: "2021-01-01" };
+      expect(record!.date()).not.toBeNull();
+      expect(record!.date()).toBeInstanceOf(Date);
+      expect(record!.date()).toEqual(new Date("2021-01-01"));
+    });
+
+    it("should return null for invalid date", function () {
+      record!.response.headers = { date: "abc" };
+      expect(record!.date()).toBeNull();
+    });
+  });
+
+  describe("toCypressResponse", function () {
+    let record: C8yDefaultPactRecord | undefined;
+
+    beforeEach(() => {
+      record = new C8yDefaultPactRecord(
+        {
+          url: "http://localhost:8080/inventory/managedObjects/1?withChildren=false",
+          headers: { "x-xsrf-token": "abcde" },
+          method: "POST",
+          body: { id: "abc123124" },
+        },
+        {
+          status: 201,
+        },
+        {},
+        { user: "test" }
+      );
+    });
+
+    it("should convert to Cypress.Response", function () {
+      const cypressResponse = record!.toCypressResponse();
+      expect(cypressResponse).not.toBeNull();
+      expect(cypressResponse).toHaveProperty("status", 201);
+      expect(cypressResponse).toHaveProperty("isOkStatusCode", true);
+      expect(cypressResponse).toHaveProperty("requestHeaders");
+      expect(cypressResponse).toHaveProperty("requestBody");
+      expect(cypressResponse).toHaveProperty("url");
+      expect(cypressResponse).toHaveProperty("method");
+    });
+  });
+});

--- a/src/shared/c8ypact/c8ypact.ts
+++ b/src/shared/c8ypact/c8ypact.ts
@@ -278,6 +278,14 @@ export interface C8yPactRecord {
    * Returns the date of the response.
    */
   date(): Date | null;
+  /**
+   * Returns if the record has a request header with the given key. Comparison is case-insensitive.
+   */
+  hasRequestHeader(key: string): boolean;
+  /**
+   * Returns the auth type of the record. Currently supports `BasicAuth`, `CookieAuth` or undefined.
+   */
+  authType(): "BasicAuth" | "CookieAuth" | "BearerAuth" | undefined;
 }
 
 export function isValidPactId(value: string): boolean {


### PR DESCRIPTION
Authorization is now determined from record auth object, but also from request headers. Using `C8Y_PACT_RUNNER_AUTH` env variable it is now possible to overwrite auth type to `CookieAuth` or `BasicAuth`.