### PR TITLE
fix(commands): Export default cy.highlight styling options

### DIFF
--- a/src/lib/commands/highlight.ts
+++ b/src/lib/commands/highlight.ts
@@ -1,6 +1,6 @@
 const { _ } = Cypress;
 
-import { C8yHighlightOptions } from "../../shared/types";
+import { C8yHighlightOptions, C8yHighlightStyleDefaults } from "../../shared/types";
 
 declare global {
   namespace Cypress {
@@ -54,13 +54,6 @@ declare global {
     extends Omit<C8yHighlightOptions, "styles" | "border"> {}
 }
 
-const HighlightStyleDefaults = {
-  outline: "2px",
-  "outline-style": "solid",
-  "outline-offset": "-2px",
-  "outline-color": "#FF9300",
-} ;
-
 Cypress.Commands.add(
   "highlight",
   { prevSubject: "element" },
@@ -77,7 +70,7 @@ Cypress.Commands.add(
       highlightElements = [];
     }
 
-    const style = { ...(highlightStyle ?? HighlightStyleDefaults) };
+    const style = { ...(highlightStyle ?? C8yHighlightStyleDefaults) };
     const consoleProps: any = {
       style: style || null,
       options: options || null,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -40,3 +40,16 @@ export interface C8yHighlightOptions {
      */
     multiple?: boolean;
   }
+
+  /**
+   * Default highlight options used by the cy.highlight() command. Use this object to override the default highlight style.
+   * 
+   * Highligh style can be any css style or an object with css properties.
+   */
+  export const C8yHighlightStyleDefaults = {
+    outline: "2px",
+    "outline-style": "solid",
+    "outline-offset": "-2px",
+    "outline-color": "#FF9300",
+  } ;
+  

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -11,45 +11,44 @@ export type C8yTenant = string;
 export type C8yBaseUrl = string;
 
 export interface C8yHighlightOptions {
-    /**
-     * The border style. Use any valid CSS border style. If provided an object, keys override the default border style.
-     * @examples ["1px solid red"]
-     */
-    border?: string | any;
-    /**
-     * The CSS styles to apply to the DOM element. Use any valid CSS styles.
-     * @examples [["background-color: yellow", "outline: dashed", "outline-offset: +3px"]]
-     */
-    styles?: any;
-    /**
-     * Overwrite the width of the highlighted element. If smaller than 1, the value is used as percentage of the element width.
-     */
-    width?: number;
-    /**
-     * Overwrite the height of the highlighted element. If smaller than 1, the value is used as percentage of the element height.
-     */
-    height?: number;
-    /**
-     * If true, existing highlights will be cleared before highlighting. The default is false.
-     * @default false
-     */
-    clear?: boolean;
-    /**
-     * If true, the highlight is applied to all elements in the selection. The default is false.
-     * @default false
-     */
-    multiple?: boolean;
-  }
-
   /**
-   * Default highlight options used by the cy.highlight() command. Use this object to override the default highlight style.
-   * 
-   * Highligh style can be any css style or an object with css properties.
+   * The border style. Use any valid CSS border style. If provided an object, keys override the default border style.
+   * @examples ["1px solid red"]
    */
-  export const C8yHighlightStyleDefaults = {
-    outline: "2px",
-    "outline-style": "solid",
-    "outline-offset": "-2px",
-    "outline-color": "#FF9300",
-  } ;
-  
+  border?: string | any;
+  /**
+   * The CSS styles to apply to the DOM element. Use any valid CSS styles.
+   * @examples [["background-color: yellow", "outline: dashed", "outline-offset: +3px"]]
+   */
+  styles?: any;
+  /**
+   * Overwrite the width of the highlighted element. If smaller than 1, the value is used as percentage of the element width.
+   */
+  width?: number;
+  /**
+   * Overwrite the height of the highlighted element. If smaller than 1, the value is used as percentage of the element height.
+   */
+  height?: number;
+  /**
+   * If true, existing highlights will be cleared before highlighting. The default is false.
+   * @default false
+   */
+  clear?: boolean;
+  /**
+   * If true, the highlight is applied to all elements in the selection. The default is false.
+   * @default false
+   */
+  multiple?: boolean;
+}
+
+/**
+ * Default highlight options used by the cy.highlight() command. Use this object to override the default highlight style.
+ *
+ * Highligh style can be any css style or an object with css properties.
+ */
+export const C8yHighlightStyleDefaults = {
+  outline: "2px",
+  "outline-style": "solid",
+  "outline-offset": "-2px",
+  "outline-color": "#FF9300",
+} as const;


### PR DESCRIPTION
The `cy.highlight()` default styling options are now exported as `C8yHighlightStyleDefaults`. Use to overwrite defaults.