### PR TITLE
fix(c8yscrn): Fixed screenshots for selector returning multiple elements

### DIFF
--- a/src/c8yscrn/runner.ts
+++ b/src/c8yscrn/runner.ts
@@ -557,8 +557,8 @@ function takeScreenshot(
         padding[1] = unionRect.top;
       }
       o.clip = {
-        x: Math.max(0, unionRect.left - padding[0]),
-        y: Math.max(0, unionRect.top - padding[1]),
+        x: unionRect.left - padding[0],
+        y: unionRect.top - padding[1],
         width: unionRect.width + padding[2] + padding[0],
         height: unionRect.height + padding[3] + padding[1],
       };

--- a/src/c8yscrn/runner.ts
+++ b/src/c8yscrn/runner.ts
@@ -16,6 +16,7 @@ import {
 import { C8yAjvSchemaMatcher } from "../contrib/ajv";
 import schema from "./schema.json";
 import { getSelector, imageName } from "./runner-helper";
+import { getUnionDOMRect } from "../lib/commands";
 
 const { _ } = Cypress;
 
@@ -266,6 +267,10 @@ export class C8yScreenshotRunner {
                           : clipArea.height,
                     };
                   }
+                  const padding = action.screenshot?.padding;
+                  if (padding != null) {
+                    options.padding = padding;
+                  }
                 }
                 handler(_.get(action, handlerKey), this, item, options);
               }
@@ -280,7 +285,7 @@ export class C8yScreenshotRunner {
               const name = imageName(item.image);
               debug(`Taking screenshot ${name}`);
               debug(`Options: ${JSON.stringify(options)}`);
-              cy.screenshot(name, options);
+              takeScreenshot(name, options);
             }
           },
         ]);
@@ -495,14 +500,71 @@ export class C8yScreenshotRunner {
     debug(`Options: ${JSON.stringify(options)}`);
 
     if (selector != null) {
-      cy.get(selector).screenshot(imageName(name), options);
+      cy.get(selector).then(($elements) => {
+        takeScreenshot(imageName(name), options, $elements);
+      });
     } else {
-      cy.screenshot(imageName(name), options);
+      takeScreenshot(imageName(name), options);
     }
   }
 
   protected getVisitObject(visit: string | Visit): Visit | undefined {
     return _.isString(visit) ? undefined : visit;
+  }
+}
+
+function takeScreenshot(
+  name: string,
+  options: Partial<
+    Cypress.Loggable & Cypress.Timeoutable & Cypress.ScreenshotOptions
+  >,
+  $elements?: JQuery<HTMLElement>
+) {
+  if ($elements == null || $elements.length === 0) {
+    cy.screenshot(name, options);
+  } else if ($elements.length === 1) {
+    cy.wrap($elements[0]).screenshot(name, options);
+  } else {
+    const unionRect = getUnionDOMRect($elements);
+    const o = _.cloneDeep(options);
+    if (options?.clip == null) {
+      const p = options?.padding;
+      let padding = _.isNumber(p) ? [p, p, p, p] : p;
+      if (!_.isArray(padding) || !_.every(padding, _.isNumber)) {
+        padding = [0, 0, 0, 0];
+      } else {
+        // map clockwise use in Cypress.Padding to our padding [left, top, right, bottom]
+        // see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Shorthand_properties
+        // this ensures compatibility with global Cypress SchreenShotOptions used with Cypress.Padding
+        
+        // [left, top, right, bottom]
+        if (padding.length === 1) {
+          padding = [padding[0], padding[0], padding[0], padding[0]];
+        } else if (padding.length === 2) {
+          padding = [padding[1], padding[0], padding[1], padding[0]];
+        } else if (padding.length === 3) {
+          padding = [padding[1], padding[0], padding[1], padding[2]];
+        } else if (padding.length >= 4) {
+          padding = [padding[3], padding[0], padding[1], padding[2]];
+        }
+      }
+      const x = unionRect.left - padding[0];
+      if (x < 0) {
+        padding[0] = unionRect.left;
+      }
+      const y = unionRect.top - padding[1];
+      if (y < 0) {
+        padding[1] = unionRect.top;
+      }
+      o.clip = {
+        x: Math.max(0, unionRect.left - padding[0]),
+        y: Math.max(0, unionRect.top - padding[1]),
+        width: unionRect.width + padding[2] + padding[0],
+        height: unionRect.height + padding[3] + padding[1],
+      };
+      delete o.padding;
+    }
+    cy.screenshot(name, o);
   }
 }
 

--- a/src/c8yscrn/schema.json
+++ b/src/c8yscrn/schema.json
@@ -470,6 +470,72 @@
                                     "$ref": "#/definitions/ScreenshotClipArea",
                                     "description": "The clip area within the screenshot image. The clip area is defined by the top-left corner (x, y) and the width and height of the clip area."
                                 },
+                                "padding": {
+                                    "anyOf": [
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 1,
+                                            "minItems": 1,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 2,
+                                            "minItems": 2,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 3,
+                                            "minItems": 3,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 4,
+                                            "minItems": 4,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "number"
+                                        }
+                                    ],
+                                    "description": "The padding applied to the screenshots of elements in px. If an array of numbers is provided, the padding is applied as defined by CSS shorthand property."
+                                },
                                 "path": {
                                     "description": "The path to store the screenshot. This is the relative path used within the screenshot folder.",
                                     "type": "string"
@@ -505,6 +571,72 @@
                                 },
                                 "data-cy": {
                                     "type": "string"
+                                },
+                                "padding": {
+                                    "anyOf": [
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 1,
+                                            "minItems": 1,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 2,
+                                            "minItems": 2,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 3,
+                                            "minItems": 3,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 4,
+                                            "minItems": 4,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "number"
+                                        }
+                                    ],
+                                    "description": "The padding applied to the screenshots of elements in px. If an array of numbers is provided, the padding is applied as defined by CSS shorthand property."
                                 },
                                 "path": {
                                     "description": "The path to store the screenshot. This is the relative path used within the screenshot folder.",

--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -359,6 +359,15 @@ export interface ScreenshotAction {
    * The clip area within the screenshot image. The clip area is defined by the top-left corner (x, y) and the width and height of the clip area.
    */
   clip?: ScreenshotClipArea;
+  /**
+   * The padding applied to the screenshots of elements in px. If an array of numbers is provided, the padding is applied as defined by CSS shorthand property.
+   */
+  padding?:
+    | number
+    | [number]
+    | [number, number]
+    | [number, number, number]
+    | [number, number, number, number];
 }
 
 export interface Action {


### PR DESCRIPTION
Screenshots for selectors returning multiple elements has been fixed. `c8yscrn` now calculates the union rect for all elements and translates it to clipping area. You can now also provide per screenshot `padding` which is also applied to union rects in case of multiple elements returned by selector. Required as Cypress does not allow taking screenshots for multiple elements.