### PR TITLE
fix(commands): Added cy.screenshot overwritten command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ General commands
 - `setLanguage`
 - `acceptCookieBanner`, `showCookieBanner`, `disableCookieBanner`
 - `disableGainsight`
-- `highlight`, `clearHighlights`
+- `highlight`, `clearHighlights`, `screenshot`
 
 Authentication related commands
 - `login`

--- a/doc/Screenshot Automation.md
+++ b/doc/Screenshot Automation.md
@@ -280,6 +280,18 @@ Using `cy.clearHighlights`, you can remove all previously applied highlights fro
 
 For more information see the js doc for `cy.highlight`, `cy.clearHighlights` and `C8yHighlightStyleDefaults`.
 
+**cy.screenshot**
+
+By importing `cumulocity-cypress/commands/screenshot`, a custom implementation of the `cy.screenshot` command is provided. This allows you to take screenshots of multiple DOM elements. For screenshots of single DOM elements or the viewport, the default Cypress implementation is be used.
+
+When taking screenshots of multiple DOM elements, the union rect of all elements is calculated and a screenshot is taken of the bounding box. This can be useful for capturing complex UI components that span multiple elements. By applying padding to the elements, you can expand the captured area around the specified elements.
+
+```typescript
+import "cumulocity-cypress/commands/screenshot";
+
+cy.get(".bottom-drawer .card-footer .btn, ").screenshot({ padding: [10, 20]});
+```
+
 ## Environment Variables
 
 Environment variables can be used to overwrite configuration settings in the `c8yscrn.config.yaml` file. This can be useful for setting sensitive information like usernames and passwords, or for providing values for CI/CD environments.

--- a/src/lib/commands/screenshot.ts
+++ b/src/lib/commands/screenshot.ts
@@ -1,0 +1,45 @@
+import { getUnionDOMRect } from "./highlight";
+
+const { _ } = Cypress;
+
+// custom implementation of screenshot command to take screenshot of
+// multiple elements by using union of their bounding client rectangles
+
+Cypress.Commands.overwrite<"screenshot", "element">(
+  "screenshot",
+  (originalFn, ...args) => {
+    const subject = args[0];
+    if (subject != null && subject.length > 1) {
+      const [_name, _options] = args.slice(1);
+
+      let o: Partial<Cypress.ScreenshotOptions> = {};
+      let n: string | undefined = undefined;
+
+      if (_.isObjectLike(_name)) {
+        o = _name as Partial<Cypress.ScreenshotOptions>;
+        n = undefined;
+      } else {
+        n = _name as string;
+        o = (_options as Cypress.ScreenshotOptions) || {};
+      }
+
+      const padding = _.pick(o, "padding");
+      const unionRect = getUnionDOMRect(subject, padding);
+      const clip: Cypress.ScreenshotOptions["clip"] = {
+        x: unionRect.left,
+        y: unionRect.top,
+        width: unionRect.width,
+        height: unionRect.height,
+      };
+      o.clip = clip;
+
+      return originalFn(
+        undefined as any,
+        n ?? (o as any),
+        n ? o : (undefined as any)
+      );
+    }
+
+    return originalFn(...args);
+  }
+);

--- a/test/cypress.config.ts
+++ b/test/cypress.config.ts
@@ -1,11 +1,22 @@
 import { defineConfig } from "cypress";
 import { configureC8yPlugin } from "../src/plugin";
 
+import * as fs from "fs";
+
 module.exports = defineConfig({
   e2e: {
     baseUrl: "http://localhost:8080",
     setupNodeEvents(on, config) {
       configureC8yPlugin(on, config);
+
+      on("after:screenshot", (details) => {
+        // delete file
+        if (details.path) {
+          console.log("deleting screenshot", details.path);
+          fs.unlinkSync(details.path);
+        }
+      });
+
       return config;
     },
   },

--- a/test/cypress/e2e/screenshot.cy.ts
+++ b/test/cypress/e2e/screenshot.cy.ts
@@ -1,0 +1,132 @@
+import "cumulocity-cypress/lib/commands/screenshot";
+
+describe("highlight", () => {
+  beforeEach(() => {
+    cy.visit("/highlight.html");
+  });
+
+  it("should take screenshot with more than one element", () => {
+    cy.get("#foo, #div")
+      .then((subject) => {
+        expect(subject).to.have.length(2);
+        return cy.wrap(subject);
+      })
+      .screenshot({
+        onAfterScreenshot: (subject, details) => {
+          expect(subject).to.have.length(1);
+          expect(details.dimensions).to.deep.eq({
+            width: 100,
+            height: 150,
+          });
+        },
+      });
+  });
+
+  it("should take screenshot with more than one element with options", () => {
+    cy.get("#padding, #padding2")
+      .then((subject) => {
+        expect(subject).to.have.length(2);
+        return cy.wrap(subject);
+      })
+      .screenshot({
+        onAfterScreenshot: (subject, details) => {
+          expect(subject).to.have.length(1);
+          expect(details.dimensions).to.deep.eq({
+            width: 220,
+            height: 120,
+          });
+        },
+        padding: 10,
+      });
+  });
+
+  it("should take screenshot with 2 padding options", () => {
+    cy.get("#padding, #padding2")
+      .then((subject) => {
+        expect(subject).to.have.length(2);
+        return cy.wrap(subject);
+      })
+      .screenshot({
+        onAfterScreenshot: (subject, details) => {
+          expect(subject).to.have.length(1);
+          expect(details.dimensions).to.deep.eq({
+            width: 240,
+            height: 120,
+          });
+        },
+        padding: [10, 20],
+      });
+  });
+
+  it("should take screenshot with 4 padding options", () => {
+    cy.get("#padding, #padding2")
+      .then((subject) => {
+        expect(subject).to.have.length(2);
+        return cy.wrap(subject);
+      })
+      .screenshot({
+        onAfterScreenshot: (subject, details) => {
+          expect(subject).to.have.length(1);
+          expect(details.dimensions).to.deep.eq({
+            width: 260,
+            height: 140,
+          });
+        },
+        padding: [10, 20, 30, 40],
+      });
+  });
+
+  it("should take screenshot with 4x0 padding options", () => {
+    cy.get("#padding, #padding2")
+      .then((subject) => {
+        expect(subject).to.have.length(2);
+        return cy.wrap(subject);
+      })
+      .screenshot({
+        onAfterScreenshot: (subject, details) => {
+          expect(subject).to.have.length(1);
+          expect(details.dimensions).to.deep.eq({
+            width: 200,
+            height: 100,
+          });
+        },
+        padding: [0, 0, 0, 0],
+      });
+  });
+
+  it("should take screenshot with null padding options", () => {
+    cy.get("#padding, #padding2")
+      .then((subject) => {
+        expect(subject).to.have.length(2);
+        return cy.wrap(subject);
+      })
+      .screenshot({
+        onAfterScreenshot: (subject, details) => {
+          expect(subject).to.have.length(1);
+          expect(details.dimensions).to.deep.eq({
+            width: 200,
+            height: 100,
+          });
+        },
+        padding: null as any,
+      });
+  });
+
+  it("should use name and options", () => {
+    cy.get("#foo, #div")
+      .then((subject) => {
+        expect(subject).to.have.length(2);
+        return cy.wrap(subject);
+      })
+      .screenshot("my-test-screenshot", {
+        onAfterScreenshot: (subject, details) => {
+          expect(subject).to.have.length(1);
+          expect(details.name).to.eq("my-test-screenshot");
+          expect(details.dimensions).to.deep.eq({
+            width: 100,
+            height: 150,
+          });
+        },
+      });
+  });
+});


### PR DESCRIPTION
Added custom implementation of `cy.screenshot` to take screenshots of multiple DOM elements. The union rect will be calculated and used for the screenshot. You need to `import "cumulocity-cypress/commands/screenshot`.