### PR TITLE
fix(c8yscrn): Allow mocking user information

### DIFF
--- a/doc/Screenshot Automation.md
+++ b/doc/Screenshot Automation.md
@@ -330,6 +330,22 @@ global:
   login: admin
 ```
 
+You can also provide additional user properties to overwrite user information in the UI. This can be useful for setting the user's name, email, phone number, etc., for the screenshots. When providing an object, `authAlias` is required to look up the user credentials.
+
+```yaml
+global:
+  login:
+    authAlias: admin
+    # additional user properties to overwrite user information in the UI
+    id: max
+    userName: Max
+    firstName: Max
+    lastName: Mustermann
+    phone: "+49123456789"
+    email: "max.mustermann@email.test"
+    displayName: "Max Mustermann"
+```
+
 Define `admin` alias in `.c8yscrn` file:
 ```properties
 admin_username: myusername
@@ -568,7 +584,7 @@ global:
 - **Example**: `"en"` or `"de"`
 
 **login**
-- **Type**: string | false
+- **Type**: string | object | false
 - **Description**: The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password env variables. If set to false, login is disabled and visit is performed unauthenticated. See the [Authentication](#authentication) section for more details.
 - **Example**: `"admin"` or `false`
 

--- a/src/c8yscrn/runner.ts
+++ b/src/c8yscrn/runner.ts
@@ -10,6 +10,7 @@ import { C8yHighlightStyleDefaults } from "../shared/types";
 import {
   Action,
   C8yScreenshotFileUploadOptions,
+  LoginUserType,
   Screenshot,
   ScreenshotSetup,
   SelectableHighlightAction,
@@ -96,10 +97,18 @@ export class C8yScreenshotRunner {
       }
     );
 
+    const login = global?.login ?? global?.user;
+    let user: LoginUserType | undefined;
+    if (_.isString(login)) {
+      user = { authAlias: login };
+    } else if (_.isObject(login) && "authAlias" in login) {
+      user = login;
+    }
+
     describe(this.config.title ?? `screenshot workflow`, () => {
       before(() => {
-        const login = global?.login ?? global?.user;
-        cy.getAuth(login as any).then((auth) => {
+        cy.wrap(user);
+        cy.getAuth(user?.authAlias as any).then((auth) => {
           if (auth != null && login !== false) {
             cy.wrap(auth, { log: false })
               .getShellVersion(global?.shell)
@@ -138,6 +147,20 @@ export class C8yScreenshotRunner {
         Cypress.session.clearAllSavedSessions();
         if (Cypress.env("C8YCTRL_MODE") != null) {
           cy.wrap(c8yctrl(), { log: false });
+        }
+
+        if (_.isObject(user)) {
+          cy.intercept(
+            { method: "GET", pathname: `/user/currentUser*` },
+            (req) => {
+              req.continue((res) => {
+                res.body = {
+                  ...res.body,
+                  ..._.omit(user, "authAlias"),
+                };
+              });
+            }
+          ).as("currentUser");
         }
       });
 

--- a/src/c8yscrn/schema.json
+++ b/src/c8yscrn/schema.json
@@ -1163,6 +1163,47 @@
             },
             "type": "object"
         },
+        "LoginUserType": {
+            "additionalProperties": false,
+            "properties": {
+                "authAlias": {
+                    "description": "The alias of the user to login. The alias is used to reference the username and password to login from env variables.",
+                    "type": "string"
+                },
+                "displayName": {
+                    "description": "The display name",
+                    "type": "string"
+                },
+                "email": {
+                    "description": "User email address.",
+                    "type": "string"
+                },
+                "firstName": {
+                    "description": "User first name.",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "Uniquely identifies a user",
+                    "type": "string"
+                },
+                "lastName": {
+                    "description": "User last name.",
+                    "type": "string"
+                },
+                "phone": {
+                    "description": "User phone number.",
+                    "type": "string"
+                },
+                "userName": {
+                    "description": "User name, unique for a given domain.\nMax: 1000 characters. Whitespaces, slashes, +$: characters not allowed",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "authAlias"
+            ],
+            "type": "object"
+        },
         "ScreenshotClipArea": {
             "additionalProperties": false,
             "properties": {
@@ -1554,6 +1595,9 @@
                 "login": {
                     "anyOf": [
                         {
+                            "$ref": "#/definitions/LoginUserType"
+                        },
+                        {
                             "enum": [
                                 false
                             ],
@@ -1563,7 +1607,7 @@
                             "type": "string"
                         }
                     ],
-                    "description": "The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password env variables. If set to false, login is disabled and visit is performed unauthenticated.",
+                    "description": "The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password env variables. If set to false, login is disabled and visit is performed unauthenticated.\nIf a user object is provided, the user to login is taken from userAlias property. All other properties are used to mock the user information in Cumulocity. This is useful to anonymize the user information in the screenshots.",
                     "examples": [
                         [
                             "admin",
@@ -1716,6 +1760,9 @@
                     "login": {
                         "anyOf": [
                             {
+                                "$ref": "#/definitions/LoginUserType"
+                            },
+                            {
                                 "enum": [
                                     false
                                 ],
@@ -1725,7 +1772,7 @@
                                 "type": "string"
                             }
                         ],
-                        "description": "The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password env variables. If set to false, login is disabled and visit is performed unauthenticated.",
+                        "description": "The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password env variables. If set to false, login is disabled and visit is performed unauthenticated.\nIf a user object is provided, the user to login is taken from userAlias property. All other properties are used to mock the user information in Cumulocity. This is useful to anonymize the user information in the screenshots.",
                         "examples": [
                             [
                                 "admin",

--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -3,6 +3,7 @@
 // using & to combine types is not supported by JSON schema and will
 // result in copying the properties of the intersection into the resulting
 // subschemas.
+import { IUser } from "@c8y/client";
 import { C8yBaseUrl, C8yHighlightOptions } from "../../shared/types";
 import { ODiffOptions } from "odiff-bin";
 
@@ -46,6 +47,24 @@ export interface GlobalOptions {
 
 export type SemverRange = string;
 
+export type LoginUserType = {
+  /**
+   * The alias of the user to login. The alias is used to reference the username and password to login from env variables.
+   */
+  authAlias: string;
+} & Partial<
+  Pick<
+    IUser,
+    | "userName"
+    | "firstName"
+    | "lastName"
+    | "email"
+    | "phone"
+    | "id"
+    | "displayName"
+  >
+>;
+
 export interface ScreenshotOptions {
   /**
    * Tags allow grouping and filtering of screenshots (optional)
@@ -74,9 +93,10 @@ export interface ScreenshotOptions {
   user?: string;
   /**
    * The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password env variables. If set to false, login is disabled and visit is performed unauthenticated.
+   * If a user object is provided, the user to login is taken from userAlias property. All other properties are used to mock the user information in Cumulocity. This is useful to anonymize the user information in the screenshots.
    * @examples [["admin", false]]
    */
-  login?: string | false;
+  login?: string | LoginUserType | false;
   /**
    * The date to simulate when running the screenshot workflows
    * @format date-time
@@ -238,7 +258,17 @@ export interface ClickAction {
   force?: boolean;
 }
 
-type CyPositionType = 'topLeft' | 'top' | 'topRight' | 'left' | 'center' | 'right' | 'bottomLeft' | 'bottom' | 'bottomRight'
+// Cypress.PositionType
+type CyPositionType =
+  | "topLeft"
+  | "top"
+  | "topRight"
+  | "left"
+  | "center"
+  | "right"
+  | "bottomLeft"
+  | "bottom"
+  | "bottomRight";
 
 export interface ScrollToAction {
   /**
@@ -251,7 +281,7 @@ export interface ScrollToAction {
    * @examples ["top", "bottom", "100px", ["top", "100px"], [0, 100], ["0%", "25%"]]
    */
   position?:
-    CyPositionType
+    | CyPositionType
     | string
     | [string, string]
     | number


### PR DESCRIPTION
The `login` configuration now allows overriding the user information of the logged in user. Use for mocking user information in the UI, including name, id, email, etc.