### PR TITLE
fix(c8yscrn): Added multiple language run support

### DIFF
--- a/src/c8yscrn/runner-helper.spec.ts
+++ b/src/c8yscrn/runner-helper.spec.ts
@@ -148,5 +148,10 @@ describe("startup", () => {
       const result = imageName("my-test-image.png.png");
       expect(result).toBe("my-test-image.png");
     });
+
+    it("should append the language if it is provided", () => {
+      const result = imageName("my-test-image.png", "de");
+      expect(result).toBe("my-test-image_de");
+    });
   });
 });

--- a/src/c8yscrn/runner-helper.ts
+++ b/src/c8yscrn/runner-helper.ts
@@ -100,6 +100,7 @@ export function parseSelector(selector: string): string[] {
   return result;
 }
 
-export function imageName(name: string): string {
-  return name.replace(/.png$/i, "");
+export function imageName(name: string, language?: string): string {
+  const n = name.replace(/.png$/i, "");
+  return language ? `${n}_${language}` : n;
 }

--- a/src/c8yscrn/schema.json
+++ b/src/c8yscrn/schema.json
@@ -1605,8 +1605,18 @@
                     ]
                 },
                 "language": {
-                    "description": "Load Cumulocity with the given language",
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Load Cumulocity with the given language"
                 },
                 "login": {
                     "anyOf": [
@@ -1770,8 +1780,18 @@
                         "type": "string"
                     },
                     "language": {
-                        "description": "Load Cumulocity with the given language",
-                        "type": "string"
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "description": "Load Cumulocity with the given language"
                     },
                     "login": {
                         "anyOf": [

--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -85,7 +85,7 @@ export interface ScreenshotOptions {
    * Load Cumulocity with the given language
    * @example "en"
    */
-  language?: "en" | "de" | string;
+  language?: "en" | "de" | string | string[];
   /**
    * Use login instead of user
    * @deprecated Use login instead


### PR DESCRIPTION
It is now possible to provide an array of languages to run the same screenshot workflow for each localization. The first language in the array is considered the default language. All screenshots of other languages will have a `_<locale>.png` in its name. 