### PR TITLE
fix(c8yscrn): Use user property for mocking user information

### DIFF
--- a/doc/Screenshot Automation.md
+++ b/doc/Screenshot Automation.md
@@ -330,13 +330,13 @@ global:
   login: admin
 ```
 
-You can also provide additional user properties to overwrite user information in the UI. This can be useful for setting the user's name, email, phone number, etc., for the screenshots. When providing an object, `authAlias` is required to look up the user credentials.
+You can also provide additional `user` property to overwrite user information in the UI. This can be useful for setting the user's name, email, phone number, etc., for the screenshots. 
 
 ```yaml
 global:
-  login:
-    authAlias: admin
-    # additional user properties to overwrite user information in the UI
+  login: admin
+  # additional user properties to overwrite user information in the UI
+  user:
     id: max
     userName: Max
     firstName: Max
@@ -584,9 +584,14 @@ global:
 - **Example**: `"en"` or `"de"`
 
 **login**
-- **Type**: string | object | false
+- **Type**: string | false
 - **Description**: The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password env variables. If set to false, login is disabled and visit is performed unauthenticated. See the [Authentication](#authentication) section for more details.
 - **Example**: `"admin"` or `false`
+
+**user**
+- **Type**: object
+- **Description**: Additional user properties to overwrite user information in the UI. This can be useful for setting the user's name, email, phone number, etc., for the screenshots.
+- **Example**: `{ id: "max", userName: "Max", firstName: "Max", lastName: "Mustermann", phone: "+49123456789", email: "mm@test.de", displayName: "Max Mustermann" }`
 
 **shell**
 - **Type**: string

--- a/src/c8yscrn/runner.ts
+++ b/src/c8yscrn/runner.ts
@@ -10,7 +10,6 @@ import { C8yHighlightStyleDefaults } from "../shared/types";
 import {
   Action,
   C8yScreenshotFileUploadOptions,
-  LoginUserType,
   Screenshot,
   ScreenshotSetup,
   SelectableHighlightAction,

--- a/src/c8yscrn/schema.json
+++ b/src/c8yscrn/schema.json
@@ -1179,13 +1179,9 @@
             },
             "type": "object"
         },
-        "LoginUserType": {
+        "Partial<Pick<IUser,\"userName\"|\"firstName\"|\"lastName\"|\"email\"|\"phone\"|\"id\"|\"displayName\">>": {
             "additionalProperties": false,
             "properties": {
-                "authAlias": {
-                    "description": "The alias of the user to login. The alias is used to reference the username and password to login from env variables.",
-                    "type": "string"
-                },
                 "displayName": {
                     "description": "The display name",
                     "type": "string"
@@ -1215,9 +1211,6 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "authAlias"
-            ],
             "type": "object"
         },
         "ScreenshotClipArea": {
@@ -1621,9 +1614,6 @@
                 "login": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/LoginUserType"
-                        },
-                        {
                             "enum": [
                                 false
                             ],
@@ -1633,7 +1623,7 @@
                             "type": "string"
                         }
                     ],
-                    "description": "The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password env variables. If set to false, login is disabled and visit is performed unauthenticated.\nIf a user object is provided, the user to login is taken from userAlias property. All other properties are used to mock the user information in Cumulocity. This is useful to anonymize the user information in the screenshots.",
+                    "description": "The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password env variables. If set to false, login is disabled and visit is performed unauthenticated.",
                     "examples": [
                         [
                             "admin",
@@ -1719,8 +1709,15 @@
                     "type": "object"
                 },
                 "user": {
-                    "description": "Use login instead of user",
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Partial<Pick<IUser,\"userName\"|\"firstName\"|\"lastName\"|\"email\"|\"phone\"|\"id\"|\"displayName\">>"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "A user object with properties used to mock the user information in Cumulocity. This is useful to anonymize the user information in the screenshots."
                 },
                 "viewportHeight": {
                     "default": 900,
@@ -1796,9 +1793,6 @@
                     "login": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/LoginUserType"
-                            },
-                            {
                                 "enum": [
                                     false
                                 ],
@@ -1808,7 +1802,7 @@
                                 "type": "string"
                             }
                         ],
-                        "description": "The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password env variables. If set to false, login is disabled and visit is performed unauthenticated.\nIf a user object is provided, the user to login is taken from userAlias property. All other properties are used to mock the user information in Cumulocity. This is useful to anonymize the user information in the screenshots.",
+                        "description": "The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password env variables. If set to false, login is disabled and visit is performed unauthenticated.",
                         "examples": [
                             [
                                 "admin",
@@ -1862,8 +1856,15 @@
                         "type": "array"
                     },
                     "user": {
-                        "description": "Use login instead of user",
-                        "type": "string"
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/Partial<Pick<IUser,\"userName\"|\"firstName\"|\"lastName\"|\"email\"|\"phone\"|\"id\"|\"displayName\">>"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "description": "A user object with properties used to mock the user information in Cumulocity. This is useful to anonymize the user information in the screenshots."
                     },
                     "visit": {
                         "anyOf": [

--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -47,12 +47,7 @@ export interface GlobalOptions {
 
 export type SemverRange = string;
 
-export type LoginUserType = {
-  /**
-   * The alias of the user to login. The alias is used to reference the username and password to login from env variables.
-   */
-  authAlias: string;
-} & Partial<
+export type LoginUserType = Partial<
   Pick<
     IUser,
     | "userName"
@@ -87,16 +82,14 @@ export interface ScreenshotOptions {
    */
   language?: "en" | "de" | string | string[];
   /**
-   * Use login instead of user
-   * @deprecated Use login instead
+   * A user object with properties used to mock the user information in Cumulocity. This is useful to anonymize the user information in the screenshots.
    */
-  user?: string;
+  user?: string | LoginUserType;
   /**
    * The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password env variables. If set to false, login is disabled and visit is performed unauthenticated.
-   * If a user object is provided, the user to login is taken from userAlias property. All other properties are used to mock the user information in Cumulocity. This is useful to anonymize the user information in the screenshots.
    * @examples [["admin", false]]
    */
-  login?: string | LoginUserType | false;
+  login?: string | false;
   /**
    * The date to simulate when running the screenshot workflows
    * @format date-time

--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -47,7 +47,7 @@ export interface GlobalOptions {
 
 export type SemverRange = string;
 
-export type LoginUserType = Partial<
+type UserType = Partial<
   Pick<
     IUser,
     | "userName"
@@ -84,7 +84,7 @@ export interface ScreenshotOptions {
   /**
    * A user object with properties used to mock the user information in Cumulocity. This is useful to anonymize the user information in the screenshots.
    */
-  user?: string | LoginUserType;
+  user?: string | UserType;
   /**
    * The alias referencing the username and password to login. Configure the username and password using *login*_username and *login*_password env variables. If set to false, login is disabled and visit is performed unauthenticated.
    * @examples [["admin", false]]


### PR DESCRIPTION
The user property now allows overriding the user information of the logged in user. Use for mocking user information in the UI, including name, id, email, etc.