### PR TITLE
fix(c8yscrn): Added selector localization support

### DIFF
--- a/doc/Screenshot Automation.md
+++ b/doc/Screenshot Automation.md
@@ -62,6 +62,9 @@ Contents of this document:
 - [Environment Variables](#environment-variables)
 - [Authentication](#authentication)
 - [Selectors](#selectors)
+  - [Localization of Selectors](#localization-of-selectors)
+  - [Using the `localized` Property](#using-the-localized-property)
+  - [Using the `language` Property](#using-the-language-property)
 - [Diffing](#diffing)
 - [Tags](#tags)
 - [Version Requirements](#version-requirements)
@@ -420,6 +423,41 @@ The names can be used for any `selector` property in the screenshot configuratio
   selector: rightDrawerHeader
 ```
 
+### Localization of Selectors
+
+When creating screenshots for applications that support multiple languages, you may encounter selectors that need to be different based on the current language of the application. The screenshot automation tool provides two ways to handle localized selectors:
+
+### Using the `localized` Property
+
+The `localized` property allows you to specify different selectors for different languages. The system will automatically use the selector that matches the current language of the application.
+
+**Example:**
+```yaml
+- click:
+    selector:
+      localized:
+        en: .btn:contains("Enum"):first
+        de: .btn:contains("Aufzählung"):first
+```
+
+In this example, the `click` action will use the `.btn:contains("Enum"):first` selector when the language is set to English (`en`) and the `.btn:contains("Aufzählung"):first` selector when the language is set to German (`de`). If the current language is neither English nor German, the action will be skipped.
+
+### Using the `language` Property
+
+The `language` property allows you to specify a language or list of languages the selector works with. If the current language does not match any of the specified languages, the action will be skipped.
+
+**Example:**
+```yaml
+- click:
+    selector: .btn:contains("Aufzählung"):first
+      language: de
+- click:
+    selector: .btn:contains("Enum"):first
+      language: en
+```
+
+In this example, the first `click` action will only be executed when the language is set to German (`de`), and the second action will only be executed when the language is set to English (`en`).
+
 ## Diffing
 
 When diffing is enabled, `c8yscrn` compares the new screenshots with the existing ones in the target folder and generates diff images that highlight the differences. Please note, diffing might only work as expected when overwriting existing screenshots. If there is no screenshot at the target location, diffing obviously won't work.
@@ -546,7 +584,7 @@ The `global` object can contain the following properties:
 global:
   viewportWidth: number
   viewportHeight: number
-  language: string
+  language: string | string[]
   user: string
   shell: string
   requires: string

--- a/src/c8yscrn/runner-helper.spec.ts
+++ b/src/c8yscrn/runner-helper.spec.ts
@@ -1,18 +1,14 @@
 /// <reference types="jest" />
 
-import {
-  getSelector,
-  imageName,
-  parseSelector,
-} from "./runner-helper";
+import { getSelector, imageName, parseSelector } from "./runner-helper";
 import { ScreenshotSetup } from "../lib/screenshots/types";
 
 describe("startup", () => {
   describe("getSelector", () => {
     const predefinedSelectors: ScreenshotSetup["selectors"] = [
-      { "testSelector": ".test-class" },
-      { "p1": "predefined 1" },
-      { "p2": "predefined 2" },
+      { testSelector: ".test-class" },
+      { p1: "predefined 1" },
+      { p2: "predefined 2" },
     ];
 
     it("should return the selector string if input is a string", () => {
@@ -44,7 +40,10 @@ describe("startup", () => {
     });
 
     it("should return the selector string if input is a array of strings", () => {
-      const result = getSelector(["my", "test", "selector"], predefinedSelectors);
+      const result = getSelector(
+        ["my", "test", "selector"],
+        predefinedSelectors
+      );
       expect(result).toBe("my test selector");
     });
 
@@ -65,34 +64,87 @@ describe("startup", () => {
 
     it("should return the selector string if predefined is object", () => {
       const result = getSelector("p1 abcd p2", {
-        "p1": "predefined 1",
-        "p2": "predefined 2",
+        p1: "predefined 1",
+        p2: "predefined 2",
       });
       expect(result).toBe("predefined 1 abcd predefined 2");
     });
 
     it("should replace multiple occurences of same predefined selector", () => {
       const result = getSelector("p1 p1", {
-        "p1": "predefined 1",
+        p1: "predefined 1",
       });
       expect(result).toBe("predefined 1 predefined 1");
     });
 
     it("should use the longest key from predefined first", () => {
       const result = getSelector("p1.2 abcd p1    p1.2.3", {
-        "p1": "predefined 1",
+        p1: "predefined 1",
         "p1.2": "predefined 1.2",
         "p1.2.3": "predefined 1.2.3",
       });
-      expect(result).toBe("predefined 1.2 abcd predefined 1    predefined 1.2.3");
+      expect(result).toBe(
+        "predefined 1.2 abcd predefined 1    predefined 1.2.3"
+      );
     });
 
     it("should not remove > selector elements", () => {
       const result = getSelector("p1 > abcd > p2", [
-        { "p1": "predefined 1" },
-        { "p2": "predefined 2" },
+        { p1: "predefined 1" },
+        { p2: "predefined 2" },
       ]);
       expect(result).toBe("predefined 1 > abcd > predefined 2");
+    });
+
+    it("should use language specific selector if language is provided", () => {
+      const selector = {
+        language: "de",
+        selector: "testSelector",
+      };
+      const result = getSelector(selector, predefinedSelectors, "de");
+      expect(result).toBe(".test-class");
+    });
+
+    it("should return undefined if language is not in the language array", () => {
+      const selector = { language: ["de", "en"], selector: "testSelector" };
+      const result = getSelector(selector, predefinedSelectors, "fr");
+      expect(result).toBeUndefined();
+    });
+
+    it("should return selector if object has language and data-cy", () => {
+      const selector = { language: "de", "data-cy": "test-cy" };
+      const result = getSelector(selector, predefinedSelectors, "de");
+      expect(result).toBe("[data-cy=test-cy]");
+    });
+
+    it("should return undefied if object is empty", () => {
+      const selector = {};
+      const result = getSelector(selector, predefinedSelectors, "de");
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined if object is empty and language is not provided", () => {
+      const selector = {};
+      const result = getSelector(selector, predefinedSelectors);
+      expect(result).toBeUndefined();
+    });
+
+    it("should return the localized selector if language is provided", () => {
+      const selector = { localized: { de: ".test-class" } };
+      const result = getSelector(selector, predefinedSelectors, "de");
+      expect(result).toBe(".test-class");
+    });
+
+    it("should return the localized selector if language is provided and it is an array", () => {
+      const selector = { localized: { de: ".test-class", en: ".test-class-en" } };
+      const result = getSelector(selector, predefinedSelectors, "en");
+      expect(result).toBe(".test-class-en");
+    });
+
+    it("should return undefined if language is not in the localized object", () => {
+      const selector = { localized: { de: ".test-class" } };
+      const result = getSelector(selector, predefinedSelectors, "fr");
+      expect(result).toBeUndefined();
     });
   });
 
@@ -118,7 +170,9 @@ describe("startup", () => {
     });
 
     it("should not split spaces within []", () => {
-      const result = parseSelector(".navbar-right > [data-cy='my test'] > .btn");
+      const result = parseSelector(
+        ".navbar-right > [data-cy='my test'] > .btn"
+      );
       expect(result).toEqual([".navbar-right", "[data-cy='my test']", ".btn"]);
     });
 

--- a/src/c8yscrn/runner-helper.ts
+++ b/src/c8yscrn/runner-helper.ts
@@ -4,7 +4,8 @@ import { ScreenshotSetup, Selector } from "../lib/screenshots/types";
 
 export function getSelector(
   selector: any | string | undefined,
-  predefined?: ScreenshotSetup["selectors"]
+  predefined?: ScreenshotSetup["selectors"],
+  language?: string
 ): string | undefined {
   if (!selector) return undefined;
 
@@ -13,7 +14,7 @@ export function getSelector(
     const sharedSelector = _.isArray(predefined)
       ? _.get(_.first(predefined.filter((s) => name in s)), name)
       : _.get(predefined, name);
-      
+
     return sharedSelector ?? name;
   };
 
@@ -22,13 +23,17 @@ export function getSelector(
     let result = name;
     if (_.isArray(predefined)) {
       for (const item of predefined) {
-        const sortedKeys = Object.keys(item).sort((a, b) => b.length - a.length);
+        const sortedKeys = Object.keys(item).sort(
+          (a, b) => b.length - a.length
+        );
         for (const key of sortedKeys) {
-            result = result.split(key).join(item[key]);
+          result = result.split(key).join(item[key]);
         }
       }
     } else {
-      const sortedKeys = Object.keys(predefined).sort((a, b) => b.length - a.length);
+      const sortedKeys = Object.keys(predefined).sort(
+        (a, b) => b.length - a.length
+      );
       for (const key of sortedKeys) {
         result = result.split(key).join(predefined[key]);
       }
@@ -43,8 +48,21 @@ export function getSelector(
   if (_.isString(selector)) {
     return getResolvedSelector(selector);
   }
-  
+
   if (_.isPlainObject(selector)) {
+    if (language != null) {
+      if ("localized" in selector ) {
+        return selector.localized[language];
+      }
+      if ("language" in selector) {
+        const l = selector.language;
+        if (_.isArray(l) && !l.includes(language)) {
+          return undefined;
+        } else if (_.isString(l) && l !== language) {
+          return undefined;
+        }
+      }
+    }
     if ("data-cy" in selector) {
       return `[data-cy=${_.get(selector, "data-cy")}]`;
     }
@@ -52,7 +70,7 @@ export function getSelector(
       return getSelector(selector.selector as Selector, predefined);
     }
   }
-  
+
   return undefined;
 }
 

--- a/src/c8yscrn/schema.json
+++ b/src/c8yscrn/schema.json
@@ -19,15 +19,60 @@
                                                     "type": "string"
                                                 }
                                             },
-                                            "required": [
-                                                "data-cy"
-                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "language": {
+                                                    "anyOf": [
+                                                        {
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                    "examples": [
+                                                        "en",
+                                                        "de",
+                                                        [
+                                                            "en",
+                                                            "de"
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "localized": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                    "examples": [
+                                                        {
+                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                        }
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
                                             "type": "object"
                                         },
                                         {
                                             "type": "string"
                                         }
-                                    ]
+                                    ],
+                                    "description": "The selector to use to select the DOM element. The selector can be defined as string or an object with properties to select the element."
                                 }
                             },
                             "required": [
@@ -42,9 +87,53 @@
                                     "type": "string"
                                 }
                             },
-                            "required": [
-                                "data-cy"
-                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "language": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                    "examples": [
+                                        "en",
+                                        "de",
+                                        [
+                                            "en",
+                                            "de"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "localized": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                    "examples": [
+                                        {
+                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                            "en": "span.label-info:not(:contains('Object'))"
+                                        }
+                                    ],
+                                    "type": "object"
+                                }
+                            },
                             "type": "object"
                         },
                         {
@@ -83,15 +172,60 @@
                                                     "type": "string"
                                                 }
                                             },
-                                            "required": [
-                                                "data-cy"
-                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "language": {
+                                                    "anyOf": [
+                                                        {
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                    "examples": [
+                                                        "en",
+                                                        "de",
+                                                        [
+                                                            "en",
+                                                            "de"
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "localized": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                    "examples": [
+                                                        {
+                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                        }
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
                                             "type": "object"
                                         },
                                         {
                                             "type": "string"
                                         }
-                                    ]
+                                    ],
+                                    "description": "The selector to use to select the DOM element. The selector can be defined as string or an object with properties to select the element."
                                 }
                             },
                             "required": [
@@ -116,9 +250,73 @@
                                     "type": "boolean"
                                 }
                             },
-                            "required": [
-                                "data-cy"
-                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "force": {
+                                    "default": false,
+                                    "description": "If true, the click event is triggered even if the element is not visible. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "language": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                    "examples": [
+                                        "en",
+                                        "de",
+                                        [
+                                            "en",
+                                            "de"
+                                        ]
+                                    ]
+                                },
+                                "multiple": {
+                                    "default": false,
+                                    "description": "If true, the click event is triggered on all matching elements. The default is false.",
+                                    "type": "boolean"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "force": {
+                                    "default": false,
+                                    "description": "If true, the click event is triggered even if the element is not visible. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "localized": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                    "examples": [
+                                        {
+                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                            "en": "span.label-info:not(:contains('Object'))"
+                                        }
+                                    ],
+                                    "type": "object"
+                                },
+                                "multiple": {
+                                    "default": false,
+                                    "description": "If true, the click event is triggered on all matching elements. The default is false.",
+                                    "type": "boolean"
+                                }
+                            },
                             "type": "object"
                         },
                         {
@@ -181,15 +379,60 @@
                                                     "type": "string"
                                                 }
                                             },
-                                            "required": [
-                                                "data-cy"
-                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "language": {
+                                                    "anyOf": [
+                                                        {
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                    "examples": [
+                                                        "en",
+                                                        "de",
+                                                        [
+                                                            "en",
+                                                            "de"
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "localized": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                    "examples": [
+                                                        {
+                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                        }
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
                                             "type": "object"
                                         },
                                         {
                                             "type": "string"
                                         }
-                                    ]
+                                    ],
+                                    "description": "The selector to use to select the DOM element. The selector can be defined as string or an object with properties to select the element."
                                 },
                                 "subjectType": {
                                     "default": "input",
@@ -264,7 +507,157 @@
                                 }
                             },
                             "required": [
-                                "data-cy",
+                                "file"
+                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "encoding": {
+                                    "description": "The encoding of the file. If not provided, the encoding is determined automatically. Default is 'utf8' or 'binary' depending of file extension.",
+                                    "enum": [
+                                        "binary",
+                                        "utf-8",
+                                        "utf8"
+                                    ],
+                                    "examples": [
+                                        [
+                                            "binary",
+                                            "utf8"
+                                        ]
+                                    ],
+                                    "type": "string"
+                                },
+                                "file": {
+                                    "description": "The path to the file to upload. Resolve the file path relative to the current working directory. Currently, only a single file of types .json, .txt, .csv, .png, .jpg, .jpeg, .gif can be uploaded. If file does not have required extension, overwrite extension in the fileName property.",
+                                    "type": "string"
+                                },
+                                "fileName": {
+                                    "description": "The name of the file to use when uploading including file extension. If not provided, the file name is determined from the file path.",
+                                    "examples": [
+                                        "file.txt"
+                                    ],
+                                    "type": "string"
+                                },
+                                "force": {
+                                    "default": false,
+                                    "description": "If true, the file is uploaded even if the element is not visible. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "language": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                    "examples": [
+                                        "en",
+                                        "de",
+                                        [
+                                            "en",
+                                            "de"
+                                        ]
+                                    ]
+                                },
+                                "mimeType": {
+                                    "description": "The MIME type of the file. If not provided, the MIME type is determined automatically.",
+                                    "examples": [
+                                        "application/json",
+                                        "text/csv",
+                                        "image/png"
+                                    ],
+                                    "type": "string"
+                                },
+                                "subjectType": {
+                                    "default": "input",
+                                    "description": "The type of the file input element. The default is 'input'.",
+                                    "enum": [
+                                        "drag-n-drop",
+                                        "input"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "file"
+                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "encoding": {
+                                    "description": "The encoding of the file. If not provided, the encoding is determined automatically. Default is 'utf8' or 'binary' depending of file extension.",
+                                    "enum": [
+                                        "binary",
+                                        "utf-8",
+                                        "utf8"
+                                    ],
+                                    "examples": [
+                                        [
+                                            "binary",
+                                            "utf8"
+                                        ]
+                                    ],
+                                    "type": "string"
+                                },
+                                "file": {
+                                    "description": "The path to the file to upload. Resolve the file path relative to the current working directory. Currently, only a single file of types .json, .txt, .csv, .png, .jpg, .jpeg, .gif can be uploaded. If file does not have required extension, overwrite extension in the fileName property.",
+                                    "type": "string"
+                                },
+                                "fileName": {
+                                    "description": "The name of the file to use when uploading including file extension. If not provided, the file name is determined from the file path.",
+                                    "examples": [
+                                        "file.txt"
+                                    ],
+                                    "type": "string"
+                                },
+                                "force": {
+                                    "default": false,
+                                    "description": "If true, the file is uploaded even if the element is not visible. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "localized": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                    "examples": [
+                                        {
+                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                            "en": "span.label-info:not(:contains('Object'))"
+                                        }
+                                    ],
+                                    "type": "object"
+                                },
+                                "mimeType": {
+                                    "description": "The MIME type of the file. If not provided, the MIME type is determined automatically.",
+                                    "examples": [
+                                        "application/json",
+                                        "text/csv",
+                                        "image/png"
+                                    ],
+                                    "type": "string"
+                                },
+                                "subjectType": {
+                                    "default": "input",
+                                    "description": "The type of the file input element. The default is 'input'.",
+                                    "enum": [
+                                        "drag-n-drop",
+                                        "input"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
                                 "file"
                             ],
                             "type": "object"
@@ -289,15 +682,60 @@
                                                     "type": "string"
                                                 }
                                             },
-                                            "required": [
-                                                "data-cy"
-                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "language": {
+                                                    "anyOf": [
+                                                        {
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                    "examples": [
+                                                        "en",
+                                                        "de",
+                                                        [
+                                                            "en",
+                                                            "de"
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "localized": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                    "examples": [
+                                                        {
+                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                        }
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
                                             "type": "object"
                                         },
                                         {
                                             "type": "string"
                                         }
-                                    ]
+                                    ],
+                                    "description": "The selector to use to select the DOM element. The selector can be defined as string or an object with properties to select the element."
                                 }
                             },
                             "required": [
@@ -312,9 +750,53 @@
                                     "type": "string"
                                 }
                             },
-                            "required": [
-                                "data-cy"
-                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "language": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                    "examples": [
+                                        "en",
+                                        "de",
+                                        [
+                                            "en",
+                                            "de"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "localized": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                    "examples": [
+                                        {
+                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                            "en": "span.label-info:not(:contains('Object'))"
+                                        }
+                                    ],
+                                    "type": "object"
+                                }
+                            },
                             "type": "object"
                         },
                         {
@@ -367,15 +849,60 @@
                                                     "type": "string"
                                                 }
                                             },
-                                            "required": [
-                                                "data-cy"
-                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "language": {
+                                                    "anyOf": [
+                                                        {
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                    "examples": [
+                                                        "en",
+                                                        "de",
+                                                        [
+                                                            "en",
+                                                            "de"
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "localized": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                    "examples": [
+                                                        {
+                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                        }
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
                                             "type": "object"
                                         },
                                         {
                                             "type": "string"
                                         }
-                                    ]
+                                    ],
+                                    "description": "The selector to use to select the DOM element. The selector can be defined as string or an object with properties to select the element."
                                 },
                                 "styles": {
                                     "description": "The CSS styles to apply to the DOM element. Use any valid CSS styles.",
@@ -442,9 +969,129 @@
                                     "type": "number"
                                 }
                             },
-                            "required": [
-                                "data-cy"
-                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "border": {
+                                    "description": "The border style. Use any valid CSS border style. If provided an object, keys override the default border style.",
+                                    "examples": [
+                                        "1px solid red"
+                                    ]
+                                },
+                                "clear": {
+                                    "default": false,
+                                    "description": "If true, existing highlights will be cleared before highlighting. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "height": {
+                                    "description": "Overwrite the height of the highlighted element. If smaller than 1, the value is used as percentage of the element height.",
+                                    "type": "number"
+                                },
+                                "language": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                    "examples": [
+                                        "en",
+                                        "de",
+                                        [
+                                            "en",
+                                            "de"
+                                        ]
+                                    ]
+                                },
+                                "multiple": {
+                                    "default": false,
+                                    "description": "If true, the highlight is applied to all elements in the selection. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "offset": {
+                                    "description": "The outline offset. The default is -2px.",
+                                    "type": "string"
+                                },
+                                "styles": {
+                                    "description": "The CSS styles to apply to the DOM element. Use any valid CSS styles.",
+                                    "examples": [
+                                        [
+                                            "background-color: yellow",
+                                            "outline: dashed",
+                                            "outline-offset: +3px"
+                                        ]
+                                    ]
+                                },
+                                "width": {
+                                    "description": "Overwrite the width of the highlighted element. If smaller than 1, the value is used as percentage of the element width.",
+                                    "type": "number"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "border": {
+                                    "description": "The border style. Use any valid CSS border style. If provided an object, keys override the default border style.",
+                                    "examples": [
+                                        "1px solid red"
+                                    ]
+                                },
+                                "clear": {
+                                    "default": false,
+                                    "description": "If true, existing highlights will be cleared before highlighting. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "height": {
+                                    "description": "Overwrite the height of the highlighted element. If smaller than 1, the value is used as percentage of the element height.",
+                                    "type": "number"
+                                },
+                                "localized": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                    "examples": [
+                                        {
+                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                            "en": "span.label-info:not(:contains('Object'))"
+                                        }
+                                    ],
+                                    "type": "object"
+                                },
+                                "multiple": {
+                                    "default": false,
+                                    "description": "If true, the highlight is applied to all elements in the selection. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "offset": {
+                                    "description": "The outline offset. The default is -2px.",
+                                    "type": "string"
+                                },
+                                "styles": {
+                                    "description": "The CSS styles to apply to the DOM element. Use any valid CSS styles.",
+                                    "examples": [
+                                        [
+                                            "background-color: yellow",
+                                            "outline: dashed",
+                                            "outline-offset: +3px"
+                                        ]
+                                    ]
+                                },
+                                "width": {
+                                    "description": "Overwrite the width of the highlighted element. If smaller than 1, the value is used as percentage of the element width.",
+                                    "type": "number"
+                                }
+                            },
                             "type": "object"
                         },
                         {
@@ -501,15 +1148,60 @@
                                                                 "type": "string"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "data-cy"
-                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "language": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                                "examples": [
+                                                                    "en",
+                                                                    "de",
+                                                                    [
+                                                                        "en",
+                                                                        "de"
+                                                                    ]
+                                                                ]
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "localized": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                                "examples": [
+                                                                    {
+                                                                        "de": "span.label-info:not(:contains('Objekt'))",
+                                                                        "en": "span.label-info:not(:contains('Object'))"
+                                                                    }
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        },
                                                         "type": "object"
                                                     },
                                                     {
                                                         "type": "string"
                                                     }
-                                                ]
+                                                ],
+                                                "description": "The selector to use to select the DOM element. The selector can be defined as string or an object with properties to select the element."
                                             },
                                             "styles": {
                                                 "description": "The CSS styles to apply to the DOM element. Use any valid CSS styles.",
@@ -576,9 +1268,129 @@
                                                 "type": "number"
                                             }
                                         },
-                                        "required": [
-                                            "data-cy"
-                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "border": {
+                                                "description": "The border style. Use any valid CSS border style. If provided an object, keys override the default border style.",
+                                                "examples": [
+                                                    "1px solid red"
+                                                ]
+                                            },
+                                            "clear": {
+                                                "default": false,
+                                                "description": "If true, existing highlights will be cleared before highlighting. The default is false.",
+                                                "type": "boolean"
+                                            },
+                                            "height": {
+                                                "description": "Overwrite the height of the highlighted element. If smaller than 1, the value is used as percentage of the element height.",
+                                                "type": "number"
+                                            },
+                                            "language": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    }
+                                                ],
+                                                "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                "examples": [
+                                                    "en",
+                                                    "de",
+                                                    [
+                                                        "en",
+                                                        "de"
+                                                    ]
+                                                ]
+                                            },
+                                            "multiple": {
+                                                "default": false,
+                                                "description": "If true, the highlight is applied to all elements in the selection. The default is false.",
+                                                "type": "boolean"
+                                            },
+                                            "offset": {
+                                                "description": "The outline offset. The default is -2px.",
+                                                "type": "string"
+                                            },
+                                            "styles": {
+                                                "description": "The CSS styles to apply to the DOM element. Use any valid CSS styles.",
+                                                "examples": [
+                                                    [
+                                                        "background-color: yellow",
+                                                        "outline: dashed",
+                                                        "outline-offset: +3px"
+                                                    ]
+                                                ]
+                                            },
+                                            "width": {
+                                                "description": "Overwrite the width of the highlighted element. If smaller than 1, the value is used as percentage of the element width.",
+                                                "type": "number"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "border": {
+                                                "description": "The border style. Use any valid CSS border style. If provided an object, keys override the default border style.",
+                                                "examples": [
+                                                    "1px solid red"
+                                                ]
+                                            },
+                                            "clear": {
+                                                "default": false,
+                                                "description": "If true, existing highlights will be cleared before highlighting. The default is false.",
+                                                "type": "boolean"
+                                            },
+                                            "height": {
+                                                "description": "Overwrite the height of the highlighted element. If smaller than 1, the value is used as percentage of the element height.",
+                                                "type": "number"
+                                            },
+                                            "localized": {
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                },
+                                                "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                "examples": [
+                                                    {
+                                                        "de": "span.label-info:not(:contains('Objekt'))",
+                                                        "en": "span.label-info:not(:contains('Object'))"
+                                                    }
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "multiple": {
+                                                "default": false,
+                                                "description": "If true, the highlight is applied to all elements in the selection. The default is false.",
+                                                "type": "boolean"
+                                            },
+                                            "offset": {
+                                                "description": "The outline offset. The default is -2px.",
+                                                "type": "string"
+                                            },
+                                            "styles": {
+                                                "description": "The CSS styles to apply to the DOM element. Use any valid CSS styles.",
+                                                "examples": [
+                                                    [
+                                                        "background-color: yellow",
+                                                        "outline: dashed",
+                                                        "outline-offset: +3px"
+                                                    ]
+                                                ]
+                                            },
+                                            "width": {
+                                                "description": "Overwrite the width of the highlighted element. If smaller than 1, the value is used as percentage of the element width.",
+                                                "type": "number"
+                                            }
+                                        },
                                         "type": "object"
                                     },
                                     {
@@ -682,15 +1494,60 @@
                                                     "type": "string"
                                                 }
                                             },
-                                            "required": [
-                                                "data-cy"
-                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "language": {
+                                                    "anyOf": [
+                                                        {
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                    "examples": [
+                                                        "en",
+                                                        "de",
+                                                        [
+                                                            "en",
+                                                            "de"
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "localized": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                    "examples": [
+                                                        {
+                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                        }
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
                                             "type": "object"
                                         },
                                         {
                                             "type": "string"
                                         }
-                                    ]
+                                    ],
+                                    "description": "The selector to use to select the DOM element. The selector can be defined as string or an object with properties to select the element."
                                 }
                             },
                             "type": "object"
@@ -704,6 +1561,201 @@
                                 },
                                 "data-cy": {
                                     "type": "string"
+                                },
+                                "padding": {
+                                    "anyOf": [
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 2,
+                                            "minItems": 2,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 1,
+                                            "minItems": 1,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 3,
+                                            "minItems": 3,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 4,
+                                            "minItems": 4,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "number"
+                                        }
+                                    ],
+                                    "description": "The padding applied to the screenshots of elements in px. If an array of numbers is provided, the padding is applied as defined by CSS shorthand property."
+                                },
+                                "path": {
+                                    "description": "The path to store the screenshot. This is the relative path used within the screenshot folder.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "clip": {
+                                    "$ref": "#/definitions/ScreenshotClipArea",
+                                    "description": "The clip area within the screenshot image. The clip area is defined by the top-left corner (x, y) and the width and height of the clip area."
+                                },
+                                "language": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                    "examples": [
+                                        "en",
+                                        "de",
+                                        [
+                                            "en",
+                                            "de"
+                                        ]
+                                    ]
+                                },
+                                "padding": {
+                                    "anyOf": [
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 2,
+                                            "minItems": 2,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 1,
+                                            "minItems": 1,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 3,
+                                            "minItems": 3,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 4,
+                                            "minItems": 4,
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "number"
+                                        }
+                                    ],
+                                    "description": "The padding applied to the screenshots of elements in px. If an array of numbers is provided, the padding is applied as defined by CSS shorthand property."
+                                },
+                                "path": {
+                                    "description": "The path to store the screenshot. This is the relative path used within the screenshot folder.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "clip": {
+                                    "$ref": "#/definitions/ScreenshotClipArea",
+                                    "description": "The clip area within the screenshot image. The clip area is defined by the top-left corner (x, y) and the width and height of the clip area."
+                                },
+                                "localized": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                    "examples": [
+                                        {
+                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                            "en": "span.label-info:not(:contains('Object'))"
+                                        }
+                                    ],
+                                    "type": "object"
                                 },
                                 "padding": {
                                     "anyOf": [
@@ -801,15 +1853,60 @@
                                                     "type": "string"
                                                 }
                                             },
-                                            "required": [
-                                                "data-cy"
-                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "language": {
+                                                    "anyOf": [
+                                                        {
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                    "examples": [
+                                                        "en",
+                                                        "de",
+                                                        [
+                                                            "en",
+                                                            "de"
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "localized": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                    "examples": [
+                                                        {
+                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                        }
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
                                             "type": "object"
                                         },
                                         {
                                             "type": "string"
                                         }
-                                    ]
+                                    ],
+                                    "description": "The selector to use to select the DOM element. The selector can be defined as string or an object with properties to select the element."
                                 }
                             },
                             "required": [
@@ -824,9 +1921,53 @@
                                     "type": "string"
                                 }
                             },
-                            "required": [
-                                "data-cy"
-                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "language": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                    "examples": [
+                                        "en",
+                                        "de",
+                                        [
+                                            "en",
+                                            "de"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "localized": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                    "examples": [
+                                        {
+                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                            "en": "span.label-info:not(:contains('Object'))"
+                                        }
+                                    ],
+                                    "type": "object"
+                                }
+                            },
                             "type": "object"
                         },
                         {
@@ -849,15 +1990,60 @@
                                                     "type": "string"
                                                 }
                                             },
-                                            "required": [
-                                                "data-cy"
-                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "language": {
+                                                    "anyOf": [
+                                                        {
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                    "examples": [
+                                                        "en",
+                                                        "de",
+                                                        [
+                                                            "en",
+                                                            "de"
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "localized": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                    "examples": [
+                                                        {
+                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                        }
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
                                             "type": "object"
                                         },
                                         {
                                             "type": "string"
                                         }
-                                    ]
+                                    ],
+                                    "description": "The selector to use to select the DOM element. The selector can be defined as string or an object with properties to select the element."
                                 },
                                 "value": {
                                     "description": "The value to set",
@@ -882,7 +2068,67 @@
                                 }
                             },
                             "required": [
-                                "data-cy",
+                                "value"
+                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "language": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                    "examples": [
+                                        "en",
+                                        "de",
+                                        [
+                                            "en",
+                                            "de"
+                                        ]
+                                    ]
+                                },
+                                "value": {
+                                    "description": "The value to set",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "value"
+                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "localized": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                    "examples": [
+                                        {
+                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                            "en": "span.label-info:not(:contains('Object'))"
+                                        }
+                                    ],
+                                    "type": "object"
+                                },
+                                "value": {
+                                    "description": "The value to set",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
                                 "value"
                             ],
                             "type": "object"
@@ -914,15 +2160,60 @@
                                                     "type": "string"
                                                 }
                                             },
-                                            "required": [
-                                                "data-cy"
-                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "language": {
+                                                    "anyOf": [
+                                                        {
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                    "examples": [
+                                                        "en",
+                                                        "de",
+                                                        [
+                                                            "en",
+                                                            "de"
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "localized": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                    "examples": [
+                                                        {
+                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                        }
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
                                             "type": "object"
                                         },
                                         {
                                             "type": "string"
                                         }
-                                    ]
+                                    ],
+                                    "description": "The selector to use to select the DOM element. The selector can be defined as string or an object with properties to select the element."
                                 },
                                 "submit": {
                                     "anyOf": [
@@ -938,15 +2229,60 @@
                                                                     "type": "string"
                                                                 }
                                                             },
-                                                            "required": [
-                                                                "data-cy"
-                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "language": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                                    "examples": [
+                                                                        "en",
+                                                                        "de",
+                                                                        [
+                                                                            "en",
+                                                                            "de"
+                                                                        ]
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "localized": {
+                                                                    "additionalProperties": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                                    "examples": [
+                                                                        {
+                                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                                        }
+                                                                    ],
+                                                                    "type": "object"
+                                                                }
+                                                            },
                                                             "type": "object"
                                                         },
                                                         {
                                                             "type": "string"
                                                         }
-                                                    ]
+                                                    ],
+                                                    "description": "The selector to use to select the DOM element. The selector can be defined as string or an object with properties to select the element."
                                                 }
                                             },
                                             "required": [
@@ -961,9 +2297,53 @@
                                                     "type": "string"
                                                 }
                                             },
-                                            "required": [
-                                                "data-cy"
-                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "language": {
+                                                    "anyOf": [
+                                                        {
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                    "examples": [
+                                                        "en",
+                                                        "de",
+                                                        [
+                                                            "en",
+                                                            "de"
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "localized": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                    "examples": [
+                                                        {
+                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                        }
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
                                             "type": "object"
                                         },
                                         {
@@ -1038,15 +2418,60 @@
                                                                     "type": "string"
                                                                 }
                                                             },
-                                                            "required": [
-                                                                "data-cy"
-                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "language": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                                    "examples": [
+                                                                        "en",
+                                                                        "de",
+                                                                        [
+                                                                            "en",
+                                                                            "de"
+                                                                        ]
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "localized": {
+                                                                    "additionalProperties": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                                    "examples": [
+                                                                        {
+                                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                                        }
+                                                                    ],
+                                                                    "type": "object"
+                                                                }
+                                                            },
                                                             "type": "object"
                                                         },
                                                         {
                                                             "type": "string"
                                                         }
-                                                    ]
+                                                    ],
+                                                    "description": "The selector to use to select the DOM element. The selector can be defined as string or an object with properties to select the element."
                                                 }
                                             },
                                             "required": [
@@ -1061,9 +2486,53 @@
                                                     "type": "string"
                                                 }
                                             },
-                                            "required": [
-                                                "data-cy"
-                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "language": {
+                                                    "anyOf": [
+                                                        {
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                    "examples": [
+                                                        "en",
+                                                        "de",
+                                                        [
+                                                            "en",
+                                                            "de"
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "localized": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                    "examples": [
+                                                        {
+                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                        }
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
                                             "type": "object"
                                         },
                                         {
@@ -1103,7 +2572,411 @@
                                 }
                             },
                             "required": [
-                                "data-cy",
+                                "value"
+                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "blur": {
+                                    "default": false,
+                                    "description": "If true, the element is blurred after typing to remove the focus. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "clear": {
+                                    "default": false,
+                                    "description": "If true, the text input is cleared before typing. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "language": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                    "examples": [
+                                        "en",
+                                        "de",
+                                        [
+                                            "en",
+                                            "de"
+                                        ]
+                                    ]
+                                },
+                                "submit": {
+                                    "anyOf": [
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "selector": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "data-cy": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "language": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                                    "examples": [
+                                                                        "en",
+                                                                        "de",
+                                                                        [
+                                                                            "en",
+                                                                            "de"
+                                                                        ]
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "localized": {
+                                                                    "additionalProperties": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                                    "examples": [
+                                                                        {
+                                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                                        }
+                                                                    ],
+                                                                    "type": "object"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "description": "The selector to use to select the DOM element. The selector can be defined as string or an object with properties to select the element."
+                                                }
+                                            },
+                                            "required": [
+                                                "selector"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "data-cy": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "language": {
+                                                    "anyOf": [
+                                                        {
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                    "examples": [
+                                                        "en",
+                                                        "de",
+                                                        [
+                                                            "en",
+                                                            "de"
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "localized": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                    "examples": [
+                                                        {
+                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                        }
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The submit selector is triggered for every entry value. Use to go over multistep forms. If the submit selector is not found, the form is not automatically continued and multistep finishes."
+                                },
+                                "value": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "items": {
+                                                "items": {
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "type": "array"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The value to type into the selected DOM element. The value can be a string or an array of strings. If an array is provided, textfields within the selector are filled with the values in the array.\n\nFor multistep forms, the value can be an array of strings. Each array represents a step in the form. The first value in the array is typed into the first textfield, the second value in the second textfield, and so on. Configure submit selector to continue to the next step of the form."
+                                }
+                            },
+                            "required": [
+                                "value"
+                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "blur": {
+                                    "default": false,
+                                    "description": "If true, the element is blurred after typing to remove the focus. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "clear": {
+                                    "default": false,
+                                    "description": "If true, the text input is cleared before typing. The default is false.",
+                                    "type": "boolean"
+                                },
+                                "localized": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                    "examples": [
+                                        {
+                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                            "en": "span.label-info:not(:contains('Object'))"
+                                        }
+                                    ],
+                                    "type": "object"
+                                },
+                                "submit": {
+                                    "anyOf": [
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "selector": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "data-cy": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "language": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                                    "examples": [
+                                                                        "en",
+                                                                        "de",
+                                                                        [
+                                                                            "en",
+                                                                            "de"
+                                                                        ]
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "localized": {
+                                                                    "additionalProperties": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                                    "examples": [
+                                                                        {
+                                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                                        }
+                                                                    ],
+                                                                    "type": "object"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "description": "The selector to use to select the DOM element. The selector can be defined as string or an object with properties to select the element."
+                                                }
+                                            },
+                                            "required": [
+                                                "selector"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "data-cy": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "language": {
+                                                    "anyOf": [
+                                                        {
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                    "examples": [
+                                                        "en",
+                                                        "de",
+                                                        [
+                                                            "en",
+                                                            "de"
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "localized": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                    "examples": [
+                                                        {
+                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                        }
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The submit selector is triggered for every entry value. Use to go over multistep forms. If the submit selector is not found, the form is not automatically continued and multistep finishes."
+                                },
+                                "value": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "items": {
+                                                "items": {
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "type": "array"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The value to type into the selected DOM element. The value can be a string or an array of strings. If an array is provided, textfields within the selector are filled with the values in the array.\n\nFor multistep forms, the value can be an array of strings. Each array represents a step in the form. The first value in the array is typed into the first textfield, the second value in the second textfield, and so on. Configure submit selector to continue to the next step of the form."
+                                }
+                            },
+                            "required": [
                                 "value"
                             ],
                             "type": "object"
@@ -1358,15 +3231,60 @@
                                                     "type": "string"
                                                 }
                                             },
-                                            "required": [
-                                                "data-cy"
-                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "language": {
+                                                    "anyOf": [
+                                                        {
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                                    "examples": [
+                                                        "en",
+                                                        "de",
+                                                        [
+                                                            "en",
+                                                            "de"
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "localized": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                                    "examples": [
+                                                        {
+                                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                                            "en": "span.label-info:not(:contains('Object'))"
+                                                        }
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
                                             "type": "object"
                                         },
                                         {
                                             "type": "string"
                                         }
-                                    ]
+                                    ],
+                                    "description": "The selector to use to select the DOM element. The selector can be defined as string or an object with properties to select the element."
                                 }
                             },
                             "required": [
@@ -1394,9 +3312,79 @@
                                     "type": "array"
                                 }
                             },
-                            "required": [
-                                "data-cy"
-                            ],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "language": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.\nIf language is not supported by the selector, the selector is ignored.",
+                                    "examples": [
+                                        "en",
+                                        "de",
+                                        [
+                                            "en",
+                                            "de"
+                                        ]
+                                    ]
+                                },
+                                "offset": {
+                                    "items": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "number"
+                                        }
+                                    ],
+                                    "maxItems": 2,
+                                    "minItems": 2,
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "localized": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "Language key and localized selector mapping. Use for example to select elements based on the language of the application.",
+                                    "examples": [
+                                        {
+                                            "de": "span.label-info:not(:contains('Objekt'))",
+                                            "en": "span.label-info:not(:contains('Object'))"
+                                        }
+                                    ],
+                                    "type": "object"
+                                },
+                                "offset": {
+                                    "items": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "number"
+                                        }
+                                    ],
+                                    "maxItems": 2,
+                                    "minItems": 2,
+                                    "type": "array"
+                                }
+                            },
                             "type": "object"
                         },
                         {

--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -473,15 +473,42 @@ export interface Action {
   wait?: number | WaitAction;
 }
 
-export type DataCySelector = {
-  "data-cy": string;
+type SelectorDataCyProperties = {
+  "data-cy"?: string;
 };
+
+type SelectorLanguageProperties = {
+  /**
+   * The language(s) this selector is valid for. If the language of the application matches the language of the selector, the selector is used to select the element.
+   * If language is not supported by the selector, the selector is ignored.
+   * @examples ["en", "de", ["en", "de"]]   
+   */
+  language?: string | string[];
+};
+
+type SelectorLocalizedProperties = {
+  /**
+   * Language key and localized selector mapping. Use for example to select elements based on the language of the application.
+   * @examples [{ "de": "span.label-info:not(:contains('Objekt'))", "en": "span.label-info:not(:contains('Object'))" }]
+   */
+  localized?: {
+    [key: string]: string;
+  };
+};
+
+type SelectorProperties =
+  | SelectorDataCyProperties
+  | SelectorLanguageProperties
+  | SelectorLocalizedProperties;
 
 export type Selector = {
-  selector: string | DataCySelector;
+  /**
+   * The selector to use to select the DOM element. The selector can be defined as string or an object with properties to select the element.
+   */
+  selector: string | SelectorProperties;
 };
 
-export type Selectable = Selector | DataCySelector;
+export type Selectable = Selector | SelectorProperties;
 
 export type SharedSelector = {
   [key: string]: string;


### PR DESCRIPTION
Selectors can now be localized using the `language` and `localized` properties of `selector`. This is required when running screenshot workflows for multiple languages and selectors reference text in the user interface.