### PR TITLE
fix(c8yscrn): ScreenshotRunner creates tests as hierarchy

### DIFF
--- a/doc/Screenshot Automation.md
+++ b/doc/Screenshot Automation.md
@@ -247,7 +247,7 @@ configureC8yScreenshotPlugin(on, config, myYamlConfig);
 Create a new file, e.g. `screenshot.cy.ts`, in your Cypress project folder to host `C8yScreenshotRunner`:
 
 ```typescript
-import { C8yScreenshotRunner } from "cumulocity-cypress/screenshot";
+import { C8yScreenshotRunner } from "cumulocity-cypress/c8yscrn";
 
 describe('My Custom Screenshot Automation', () => {
   const runner = new C8yScreenshotRunner();
@@ -255,7 +255,27 @@ describe('My Custom Screenshot Automation', () => {
 });
 ```
 
-When integrating into an existing Cypress project, you'll use the `C8yScreenshotRunner` in your test files. See the "Using C8yScreenshotRunner in Your Project" section for details.
+When integrating into an existing Cypress project, you'll use the `C8yScreenshotRunner` in your test files. 
+
+You can also use the `C8yScreenshotRunner` in your existing Cypress tests for selected workflows. This would allow to run workflows with different setups, as for example different interceptions, before taking the screenshots.
+
+```typescript
+
+import { C8yScreenshotRunner } from "cumulocity-cypress/c8yscrn";
+
+describe('My Custom Screenshot Automation', () => {
+
+  const runner = new C8yScreenshotRunner();
+  
+  context("Requires mocked users", () => {
+    beforeEach(() => {
+      cy.intercept("GET", "/users", { fixture: "user.json" });
+    });
+
+    runner.run({ tags: ["user"] });
+  });
+});
+```
 
 #### Custom Commands
 

--- a/src/c8yscrn/cypress/screenshots.cy.js
+++ b/src/c8yscrn/cypress/screenshots.cy.js
@@ -8,4 +8,4 @@ const { C8yScreenshotRunner } = require("./../runner");
 // undefined is passed as config, so the runner will look for the configuration
 // in the environment variables created by startup script.
 const c8yscrn = new C8yScreenshotRunner(undefined);
-c8yscrn.run();
+c8yscrn.runSuite();

--- a/src/c8yscrn/runner-helper.spec.ts
+++ b/src/c8yscrn/runner-helper.spec.ts
@@ -1,6 +1,11 @@
 /// <reference types="jest" />
 
-import { getSelector, imageName, parseSelector } from "./runner-helper";
+import {
+  buildTestHierarchyWithOptions,
+  getSelector,
+  imageName,
+  parseSelector,
+} from "./runner-helper";
 import { ScreenshotSetup } from "../lib/screenshots/types";
 
 describe("startup", () => {
@@ -136,7 +141,9 @@ describe("startup", () => {
     });
 
     it("should return the localized selector if language is provided and it is an array", () => {
-      const selector = { localized: { de: ".test-class", en: ".test-class-en" } };
+      const selector = {
+        localized: { de: ".test-class", en: ".test-class-en" },
+      };
       const result = getSelector(selector, predefinedSelectors, "en");
       expect(result).toBe(".test-class-en");
     });
@@ -206,6 +213,87 @@ describe("startup", () => {
     it("should append the language if it is provided", () => {
       const result = imageName("my-test-image.png", "de");
       expect(result).toBe("my-test-image_de");
+    });
+  });
+
+  describe("buildTestHierarchiesWithOptions", () => {
+    it("should return the hierarchy with the provided tags", () => {
+      const objects = [
+        { title: "test1", tags: ["tag1"] },
+        { title: "test2", tags: ["tag2"] },
+        { title: "test3", tags: ["tag3"] },
+      ];
+      const options = { tags: ["tag1", "tag3"] };
+      const result = buildTestHierarchyWithOptions(objects as any, options);
+      expect(result).toEqual({
+        test1: { tags: ["tag1"], title: "test1" },
+        test3: { tags: ["tag3"], title: "test3" },
+      });
+    });
+
+    it("should return the hierarchy with the provided titles", () => {
+      const objects = [
+        { title: ["dtm", "screenshots", "test1"], tags: ["tag1"] },
+        { title: ["dtm", "screenshots", "test2"], tags: ["tag2"] },
+        { title: ["dtm", "test", "test3"], tags: ["tag3"] },
+      ];
+
+      const options = { titles: ["dtm", "screenshots"] };
+      const result = buildTestHierarchyWithOptions(objects as any, options);
+      expect(result).toEqual({
+        dtm: {
+          screenshots: {
+            test1: { tags: ["tag1"], title: ["dtm", "screenshots", "test1"] },
+            test2: { tags: ["tag2"], title: ["dtm", "screenshots", "test2"] },
+          },
+        },
+      });
+    });
+
+    it("should return the hierarchy with the provided images", () => {
+      const objects = [
+        { image: "test1", tags: ["tag1"] },
+        { image: "test2", tags: ["tag2"] },
+        { image: "test3", tags: ["tag3"] },
+      ];
+      const options = { images: ["test1", "test3"] };
+      const result = buildTestHierarchyWithOptions(objects as any, options);
+      expect(result).toEqual({
+        test1: { tags: ["tag1"], image: "test1" },
+        test3: { tags: ["tag3"], image: "test3" },
+      });
+    });
+
+    it("should return the hierarchy with the provided tags and titles", () => {
+      const objects = [
+        { title: ["dtm", "screenshots", "test1"], tags: ["tag1"] },
+        { title: ["dtm", "screenshots", "test2"], tags: ["tag2"] },
+        { title: ["dtm", "test", "test3"], tags: ["tag3"] },
+      ];
+
+      const options = { tags: ["tag1"], titles: ["dtm", "screenshots"] };
+      const result = buildTestHierarchyWithOptions(objects as any, options);
+      expect(result).toEqual({
+        dtm: {
+          screenshots: {
+            test1: { tags: ["tag1"], title: ["dtm", "screenshots", "test1"] },
+          },
+        },
+      });
+    });
+
+    it("should return the hierarchy with the provided tags and images", () => {
+      const objects = [
+        { image: "test1", tags: ["tag1"] },
+        { image: "test2", tags: ["tag2"] },
+        { image: "test3", tags: ["tag3"] },
+      ];
+
+      const options = { tags: ["tag1"], images: ["test1"] };
+      const result = buildTestHierarchyWithOptions(objects as any, options);
+      expect(result).toEqual({
+        test1: { tags: ["tag1"], image: "test1" },
+      });
     });
   });
 });

--- a/src/c8yscrn/runner-helper.ts
+++ b/src/c8yscrn/runner-helper.ts
@@ -140,13 +140,15 @@ export function buildTestHierarchyWithOptions(
 ): C8yTestHierarchyTree<Screenshot & ScreenshotOptions> {
   return buildTestHierarchy(objects, (item) => {
     if (options.tags != null && item.tags != null) {
-      if (_.intersection(options.tags, to_array(item.tags)).length === 0) {
+      if (
+        _.intersection(options.tags, to_array(item.tags) ?? []).length === 0
+      ) {
         return undefined;
       }
     }
 
     const titles = to_array(item.title) ?? item.image?.split(/[/\\]/);
-    if (options.titles != null && titles != null) {
+    if (options.titles != null && titles != null && !_.isEmpty(titles)) {
       if (!options.titles.every((title, index) => titles[index] === title)) {
         return undefined;
       }

--- a/src/c8yscrn/runner.ts
+++ b/src/c8yscrn/runner.ts
@@ -5,7 +5,11 @@ import "../lib/commands/screenshot";
 import "cypress-file-upload";
 
 import { pactId } from "../shared/c8ypact";
-import { C8yHighlightStyleDefaults } from "../shared/types";
+import { buildTestHierarchy } from "../shared/util";
+import {
+  C8yHighlightStyleDefaults,
+  C8yTestHierarchyTree,
+} from "../shared/types";
 
 import { CyHttpMessages } from "cypress/types/net-stubbing";
 
@@ -33,6 +37,16 @@ export type C8yScreenshotActionHandler = (
 ) => void;
 
 const taskLog = { log: true };
+
+type Workflow = Screenshot & ScreenshotOptions;
+
+const CyScreenshotSettingsKeys = [
+  "capture",
+  "scale",
+  "padding",
+  "overwrite",
+  "disableTimersAndAnimations",
+] as const;
 
 export class C8yScreenshotRunner {
   readonly config: ScreenshotSetup;
@@ -80,36 +94,22 @@ export class C8yScreenshotRunner {
     this.actionHandlers[key] = handler.bind(this);
   }
 
+  // shorthand for this.config?.global
+  private g = (key?: string) => {
+    return key != null ? _.get(this.config?.global, key) : this.config?.global;
+  };
+
   run() {
     // reset language
     this.language = undefined;
-    // init global settings
-    const global = this.config.global;
 
-    const CyScreenshotSettingsKeys = [
-      "capture",
-      "scale",
-      "padding",
-      "overwrite",
-      "disableTimersAndAnimations",
-    ];
-    const defaultOptions: Partial<Cypress.ScreenshotOptions> = _.defaults(
-      _.omitBy(_.pick(global ?? {}, CyScreenshotSettingsKeys), _.isNil),
-      {
-        overwrite: false,
-        scale: false,
-        disableTimersAndAnimations: true,
-        capture: "viewport" as const,
-      }
-    );
-
-    let globalLogin = global?.login;
-    if (_.isString(global?.user) && globalLogin == null) {
+    let globalLogin = this.g("login");
+    if (_.isString(this.g("user")) && globalLogin == null) {
       // backwards compatibility
-      globalLogin = global.user;
+      globalLogin = this.g("user") as ScreenshotOptions["login"];
     }
 
-    describe(this.config.title ?? `screenshot workflow`, () => {
+    describe(this.config.title ?? `c8yscrn`, () => {
       before(() => {
         (_.isString(globalLogin)
           ? cy.getAuth(globalLogin)
@@ -117,11 +117,11 @@ export class C8yScreenshotRunner {
         ).then((auth) => {
           if (auth != null && globalLogin !== false) {
             cy.wrap(auth, { log: false })
-              .getShellVersion(global?.shell)
+              .getShellVersion(this.g()?.shell)
               .then((version) => {
                 debug(
                   `Set shell version ${version} for ${
-                    global?.shell ?? Cypress.env("C8Y_SHELL_NAME")
+                    this.g()?.shell ?? Cypress.env("C8Y_SHELL_NAME")
                   } `
                 );
               });
@@ -149,24 +149,37 @@ export class C8yScreenshotRunner {
         });
       });
 
-      beforeEach(() => {
-        Cypress.session.clearAllSavedSessions();
-        if (Cypress.env("C8YCTRL_MODE") != null) {
-          cy.wrap(c8yctrl(), { log: false });
-        }
-      });
+      const testHierarchy = buildTestHierarchy<Workflow>(
+        this.config.screenshots,
+        (item) => item.image.split(/[/\\]/)
+      );
+      this.createTestsFromHierarchy(testHierarchy);
+    });
+  }
 
-      this.config.screenshots?.forEach((item) => {
+  protected createTestsFromHierarchy(
+    hierarchy: C8yTestHierarchyTree<Workflow>
+  ): void {
+    beforeEach(() => {
+      Cypress.session.clearAllSavedSessions();
+      if (Cypress.env("C8YCTRL_MODE") != null) {
+        cy.wrap(c8yctrl(), { log: false });
+      }
+    });
+
+    Object.keys(hierarchy).forEach((key: string) => {
+      const subTree = hierarchy[key];
+      if (isWorkflow(subTree)) {
         const annotations: any = {};
-
-        const required = item.requires ?? global?.requires;
+        const item = subTree;
+        const required = item.requires ?? this.g()?.requires;
         if (required != null) {
           annotations.requires = {
             shell: _.isArray(required) ? required : [required],
           };
         }
 
-        const tags = item.tags ?? this.config.global?.tags;
+        const tags = item.tags ?? this.g("tags");
         if (tags != null) {
           annotations.tags = _.isArray(tags) ? tags : [tags];
         }
@@ -176,155 +189,168 @@ export class C8yScreenshotRunner {
           annotations.scrollBehavior = item.scrollBehavior;
         }
 
-        let fn = item.only === true ? it.only : it;
-        fn = item.skip === true ? it.skip : fn;
-
-        const l = item.language ?? global?.language ?? "en";
+        const l: string | string[] =
+          item.language ?? this.g("language") ?? "en";
         const languages = _.isArray(l) ? l : [l];
+        const defaultLanguage = languages[0];
+
         languages.forEach((language) => {
-          this.language = language === languages[0] ? undefined : language;
+          this.language = language === defaultLanguage ? undefined : language;
 
-          fn.apply(null, [
-            `${item.image} (${language})`,
-            annotations,
-            // @ts-expect-error
-            () => {
-              let login =
-                item.login ?? global?.login ?? item.user ?? global?.user;
-              const skipLogin = login === false;
-              if (!_.isString(login)) {
-                login = undefined;
-              }
+          let fn = item.only === true ? it.only : it;
+          fn = item.skip === true ? it.skip : fn;
 
-              debug(`Running screenshot: ${item.image}`);
-              debug(`Using annotations: ${JSON.stringify(annotations)}`);
+          const l = item.language ?? this.g("language") ?? "en";
+          const languages = _.isArray(l) ? l : [l];
+          languages.forEach((language) => {
+            this.language = language === defaultLanguage ? undefined : language;
 
-              const width =
-                item.settings?.viewportWidth ?? global?.viewportWidth ?? 1440;
-              const height =
-                item.settings?.viewportWidth ?? global?.viewportHeight ?? 900;
-              cy.viewport(width, height);
-
-              const options = _.defaults(
-                _.omitBy(
-                  _.pick(item.settings ?? {}, CyScreenshotSettingsKeys),
-                  _.isNil
-                ),
-                defaultOptions
-              );
-
-              const visitDate = item.date ?? global?.date;
-              if (visitDate) {
-                debug(`Setting visit date to ${visitDate}`);
-                cy.clock(new Date(visitDate));
-              }
-
-              const user = item.user ?? global?.user;
-              this.interceptCurrentUser(user);
-
-              (_.isString(login) ? cy.getAuth(login) : cy.wrap(undefined)).then(
-                (auth) => {
-                  if (auth != null && !skipLogin) {
-                    const username =
-                      auth.user ?? auth.username ?? auth.userAlias;
-                    debug(`Logging in as ${username}`);
-                    cy.wrap(auth, { log: false }).login();
-                  } else {
-                    if (!skipLogin) {
-                      debug(
-                        `Skipped login. ${
-                          user ? user + "not" : "No login or auth"
-                        } configured.`
-                      );
-                    } else {
-                      debug(`Skipped login. Login is disabled.`);
-                    }
-                  }
-                }
-              );
-
-              const visitObject = this.getVisitObject(item.visit);
-              const url = visitObject?.url ?? (item.visit as string);
-              const visitSelector =
-                visitObject?.selector ??
-                global?.visitWaitSelector ??
-                "c8y-drawer-outlet c8y-app-icon .c8y-icon";
-              debug(`Visiting ${url} Selector: ${visitSelector}`);
-              const visitTimeout = visitObject?.timeout;
-
-              cy.visitAndWaitForSelector(
-                url,
-                language as any,
-                visitSelector,
-                visitTimeout
-              );
-
-              if (global?.disableTimersAndAnimations === true) {
-                cy.document().then((doc) => {
-                  const style = doc.createElement("style");
-                  style.innerHTML = `
-                * {
-                 animation: none !important;
-                 transition: none !important;
-                }
-                `;
-                  doc.head.appendChild(style);
-                });
-              }
-
-              let actions = item.actions == null ? [] : item.actions;
-              actions = _.isArray(actions) ? actions : [actions];
-              actions.forEach((action) => {
-                const handlerKey = Object.keys(action)[0];
-                const handler = this.actionHandlers[handlerKey];
-                if (handler) {
-                  if (
-                    isScreenshotAction(action) &&
-                    !(
-                      _.isString(action.screenshot) ||
-                      _.isArray(action.screenshot)
-                    )
-                  ) {
-                    const clipArea = action.screenshot?.clip;
-                    if (clipArea) {
-                      options["clip"] = {
-                        x: Math.max(clipArea.x, 0),
-                        y: Math.max(clipArea.y, 0),
-                        width:
-                          clipArea.width < 0
-                            ? width + clipArea.width
-                            : clipArea.width,
-                        height:
-                          clipArea.height < 0
-                            ? height + clipArea.height
-                            : clipArea.height,
-                      };
-                    }
-                    const padding = action.screenshot?.padding;
-                    if (padding != null) {
-                      options.padding = padding;
-                    }
-                  }
-                  handler(_.get(action, handlerKey), this, item, options);
-                }
-              });
-
-              const lastAction = _.last(actions);
-              if (
-                _.isEmpty(actions) ||
-                !lastAction ||
-                !isScreenshotAction(lastAction)
-              ) {
-                const name = imageName(item.image, this.language);
-                debug(`Taking screenshot ${name}`);
-                debug(`Options: ${JSON.stringify(options)}`);
-                cy.screenshot(name, options);
-              }
-            },
-          ]);
+            fn.apply(null, [
+              `${key} (${language})`,
+              annotations,
+              // @ts-expect-error
+              () => {
+                debug(`Running screenshot: ${item.image}`);
+                debug(`Using annotations: ${JSON.stringify(annotations)}`);
+                this.runTest(subTree, language);
+              },
+            ]);
+          });
         });
-      });
+      } else {
+        const that = this;
+        context(key, function () {
+          that.createTestsFromHierarchy(subTree);
+        });
+      }
     });
+  }
+
+  protected runTest(item: Workflow, language?: string) {
+    let login = item.login ?? this.g("login") ?? item.user ?? this.g("user");
+    const skipLogin = login === false;
+    if (!_.isString(login)) {
+      login = undefined;
+    }
+
+    const width =
+      item.settings?.viewportWidth ?? this.g("viewportWidth") ?? 1440;
+    const height =
+      item.settings?.viewportWidth ?? this.g("viewportHeight") ?? 900;
+    cy.viewport(width, height);
+
+    const defaultOptions: Partial<Cypress.ScreenshotOptions> = _.defaults(
+      _.omitBy(_.pick(this.g() ?? {}, CyScreenshotSettingsKeys), _.isNil),
+      {
+        overwrite: false,
+        scale: false,
+        disableTimersAndAnimations: true,
+        capture: "viewport" as const,
+      }
+    );
+
+    const options = _.defaults(
+      _.omitBy(_.pick(item.settings ?? {}, CyScreenshotSettingsKeys), _.isNil),
+      defaultOptions
+    );
+
+    const visitDate = item.date ?? this.g("date");
+    if (visitDate) {
+      debug(`Setting visit date to ${visitDate}`);
+      cy.clock(new Date(visitDate));
+    }
+
+    const user = item.user ?? this.g("user");
+    this.interceptCurrentUser(user);
+
+    (_.isString(login) ? cy.getAuth(login) : cy.wrap(undefined)).then(
+      (auth) => {
+        if (auth != null && !skipLogin) {
+          const username = auth.user ?? auth.username ?? auth.userAlias;
+          debug(`Logging in as ${username}`);
+          cy.wrap(auth, { log: false }).login();
+        } else {
+          if (!skipLogin) {
+            debug(
+              `Skipped login. ${
+                user ? user + "not" : "No login or auth"
+              } configured.`
+            );
+          } else {
+            debug(`Skipped login. Login is disabled.`);
+          }
+        }
+      }
+    );
+
+    const visitObject = this.getVisitObject(item.visit);
+    const url = visitObject?.url ?? (item.visit as string);
+    const visitSelector =
+      visitObject?.selector ??
+      this.g("visitWaitSelector") ??
+      "c8y-drawer-outlet c8y-app-icon .c8y-icon";
+    debug(`Visiting ${url} Selector: ${visitSelector}`);
+    const visitTimeout = visitObject?.timeout;
+
+    cy.visitAndWaitForSelector(
+      url,
+      language as C8yLanguage,
+      visitSelector,
+      visitTimeout
+    );
+
+    if (this.g("disableTimersAndAnimations") === true) {
+      cy.document().then((doc) => {
+        const style = doc.createElement("style");
+        style.innerHTML = `
+        * {
+         animation: none !important;
+         transition: none !important;
+        }
+        `;
+        doc.head.appendChild(style);
+      });
+    }
+
+    let actions = item.actions == null ? [] : item.actions;
+    actions = _.isArray(actions) ? actions : [actions];
+    actions.forEach((action) => {
+      const handlerKey = Object.keys(action)[0];
+      const handler = this.actionHandlers[handlerKey];
+      if (handler) {
+        if (
+          isScreenshotAction(action) &&
+          !(_.isString(action.screenshot) || _.isArray(action.screenshot))
+        ) {
+          const clipArea = action.screenshot?.clip;
+          if (clipArea) {
+            options["clip"] = {
+              x: Math.max(clipArea.x, 0),
+              y: Math.max(clipArea.y, 0),
+              width:
+                clipArea.width < 0 ? width + clipArea.width : clipArea.width,
+              height:
+                clipArea.height < 0
+                  ? height + clipArea.height
+                  : clipArea.height,
+            };
+          }
+          const padding = action.screenshot?.padding;
+          if (padding != null) {
+            options.padding = padding;
+          }
+        }
+        handler(_.get(action, handlerKey), this, item, options);
+      }
+    });
+
+    const lastAction = _.last(actions);
+    if (_.isEmpty(actions) || !lastAction || !isScreenshotAction(lastAction)) {
+      const name = imageName(item.image, this.language);
+      debug(`Taking screenshot ${name}`);
+      debug(`Options: ${JSON.stringify(options)}`);
+      cy.screenshot(name, options);
+    }
   }
 
   protected click(action: Action["click"]) {
@@ -694,4 +720,8 @@ export function isScreenshotAction(action: Action): boolean {
 function loadDataFromLocalStorage(key: string) {
   const data = localStorage.getItem(key);
   return data ? JSON.parse(data) : null;
+}
+
+function isWorkflow(obj: any): obj is Workflow {
+  return "image" in obj;
 }

--- a/src/c8yscrn/runner.ts
+++ b/src/c8yscrn/runner.ts
@@ -5,7 +5,7 @@ import "../lib/commands/screenshot";
 import "cypress-file-upload";
 
 import { pactId } from "../shared/c8ypact";
-import { buildTestHierarchy } from "../shared/util";
+import { buildTestHierarchy, to_array } from "../shared/util";
 import {
   C8yHighlightStyleDefaults,
   C8yTestHierarchyTree,
@@ -104,7 +104,7 @@ export class C8yScreenshotRunner {
     this.language = undefined;
     const testHierarchy = buildTestHierarchy<Workflow>(
       this.config.screenshots,
-      (item) => item.image.split(/[/\\]/)
+      (item) => to_array(item.title) ?? item.image.split(/[/\\]/)
     );
     this.createTestsFromHierarchy(testHierarchy);
   }

--- a/src/c8yscrn/schema.json
+++ b/src/c8yscrn/schema.json
@@ -3850,6 +3850,20 @@
                         },
                         "type": "array"
                     },
+                    "title": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "description": "The title of the screenshot workflow. The title is used to group the screenshots. To provide a hierarchy of titles, use an array of strings."
+                    },
                     "user": {
                         "anyOf": [
                             {

--- a/src/lib/pact/cypresspact.ts
+++ b/src/lib/pact/cypresspact.ts
@@ -43,7 +43,7 @@ import { C8yPactFetchClient } from "./fetchclient";
 import { validateBaseUrl } from "../../shared/c8ypact/url";
 import { C8yCypressEnvPreprocessor } from "./cypresspreprocessor";
 import { C8yBaseUrl } from "../../shared/types";
-import { toBoolean } from "../../shared/util";
+import { to_boolean } from "../../shared/util";
 
 declare global {
   namespace Cypress {
@@ -331,7 +331,7 @@ if (_.get(Cypress, "__c8ypact.initialized") === undefined) {
           ignore: Cypress.env("C8Y_PACT_PREPROCESSOR_IGNORE"),
           obfuscate: Cypress.env("C8Y_PACT_PREPROCESSOR_OBFUSCATE"),
           obfuscationPattern: Cypress.env("C8Y_PACT_PREPROCESSOR_PATTERN"),
-          ignoreCase: toBoolean(Cypress.env("C8Y_PACT_PREPROCESSOR_IGNORE_CASE"), true),
+          ignoreCase: to_boolean(Cypress.env("C8Y_PACT_PREPROCESSOR_IGNORE_CASE"), true),
         },
       };
     },

--- a/src/lib/pact/cypresspreprocessor.ts
+++ b/src/lib/pact/cypresspreprocessor.ts
@@ -1,4 +1,4 @@
-import { toBoolean } from "../../shared/util";
+import { to_boolean } from "../../shared/util";
 import {
   C8yDefaultPactPreprocessor,
   C8yPact,
@@ -47,7 +47,7 @@ export class C8yCypressEnvPreprocessor extends C8yDefaultPactPreprocessor {
         ignore: Cypress.env("C8Y_PACT_PREPROCESSOR_IGNORE"),
         obfuscate: Cypress.env("C8Y_PACT_PREPROCESSOR_OBFUSCATE"),
         obfuscationPattern: Cypress.env("C8Y_PACT_PREPROCESSOR_PATTERN"),
-        ignoreCase: toBoolean(
+        ignoreCase: to_boolean(
           Cypress.env("C8Y_PACT_PREPROCESSOR_IGNORE_CASE"),
           true
         ),

--- a/src/lib/pact/runner.ts
+++ b/src/lib/pact/runner.ts
@@ -189,21 +189,21 @@ export class C8yDefaultPactRunner implements C8yPactRunner {
           }
         }
 
-        let users = to_array(record.auth?.userAlias || record.auth?.user).map(
-          (item) => {
-            if ((item || "").split("/").length > 1) {
-              return item?.split("/")?.slice(1)?.join("/");
-            } else {
-              return item;
-            }
+        let users: (string | undefined)[] = (
+          to_array(record.auth?.userAlias ?? record.auth?.user) ?? []
+        ).map((item) => {
+          if ((item || "").split("/").length > 1) {
+            return item?.split("/")?.slice(1)?.join("/");
+          } else {
+            return item;
           }
-        );
+        });
 
         if (url === "/devicecontrol/deviceCredentials") {
-          users = to_array("devicebootstrap");
+          users = to_array("devicebootstrap") ?? [];
         }
 
-        if (users.length === 0) {
+        if (users?.length === 0) {
           users = [undefined];
         }
 

--- a/src/lib/screenshots/types.ts
+++ b/src/lib/screenshots/types.ts
@@ -110,6 +110,10 @@ export interface Screenshot {
    */
   image: string;
   /**
+   * The title of the screenshot workflow. The title is used to group the screenshots. To provide a hierarchy of titles, use an array of strings.
+   */
+  title?: string | string[];
+  /**
    * The URI to visit. This typically a relative path to the baseUrl.
    * @examples ["/apps/cockpit/index.html#/"]
    */

--- a/src/shared/c8yctrl/httpcontroller.ts
+++ b/src/shared/c8yctrl/httpcontroller.ts
@@ -44,7 +44,7 @@ import fs from "fs";
 import path from "path";
 
 import { isVersionSatisfyingRequirements } from "../versioning";
-import { safeStringify, toBoolean } from "../util";
+import { safeStringify, to_boolean } from "../util";
 import { getPackageVersion } from "../util-node";
 
 import swaggerUi from "swagger-ui-express";
@@ -383,7 +383,7 @@ export class C8yPactHttpController {
 
       this.mode = mode as C8yPactMode;
       this.recordingMode = recordingMode as C8yPactRecordingMode;
-      this._isStrictMocking = toBoolean(strictMocking, this._isStrictMocking);
+      this._isStrictMocking = to_boolean(strictMocking, this._isStrictMocking);
 
       if (!id || !_.isString(id)) {
         res.status(404).send("Missing or invalid pact id");
@@ -396,7 +396,7 @@ export class C8yPactHttpController {
         this.currentPact != null;
       const clearPact =
         _.isString(clear) &&
-        (_.isEmpty(clear) || toBoolean(clear, false) === true);
+        (_.isEmpty(clear) || to_boolean(clear, false) === true);
 
       this.logger.debug(
         `mode: ${this.mode}, recordingMode: ${this.recordingMode}, strictMocking: ${this._isStrictMocking}, refresh: ${refreshPact}, clear: ${clearPact}`

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -52,3 +52,5 @@ export const C8yHighlightStyleDefaults = {
   "outline-offset": "-2px",
   "outline-color": "#FF9300",
 } as const;
+
+export type C8yTestHierarchyTree<T> = { [key: string]: T | C8yTestHierarchyTree<T> };

--- a/src/shared/util.spec.ts
+++ b/src/shared/util.spec.ts
@@ -2,6 +2,7 @@ import {
   buildTestHierarchy,
   get_i,
   sanitizeStringifiedObject,
+  to_array,
   toBoolean,
   toSensitiveObjectKeyPath,
 } from "./util";
@@ -204,6 +205,25 @@ describe("util", () => {
       const obj = { test: "test", Complex: { key: { token: "value" } } };
       const result = get_i(obj, "");
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("to_array", () => {
+    it("should return undefined if value is undefined", () => {
+      const result = to_array(undefined);
+      expect(result).toBeUndefined();
+    });
+
+    it("should return value if it is already an array", () => {
+      const value = [1, 2, 3];
+      const result = to_array(value);
+      expect(result).toBe(value);
+    });
+
+    it("should return value as an array", () => {
+      const value = 1;
+      const result = to_array(value);
+      expect(result).toEqual([1]);
     });
   });
 

--- a/src/shared/util.spec.ts
+++ b/src/shared/util.spec.ts
@@ -3,7 +3,7 @@ import {
   get_i,
   sanitizeStringifiedObject,
   to_array,
-  toBoolean,
+  to_boolean,
   toSensitiveObjectKeyPath,
 } from "./util";
 
@@ -48,46 +48,46 @@ describe("util", () => {
     ).toEqual("{ password: ***, username: myuser }");
   });
 
-  describe("toBoolean", () => {
+  describe("to_boolean", () => {
     it("should return the default value if input is null", () => {
       const defaultValue = true;
-      const result = toBoolean(null as any, defaultValue);
+      const result = to_boolean(null as any, defaultValue);
       expect(result).toBe(defaultValue);
     });
 
     it("should return the default value if input is not a string", () => {
       const defaultValue = false;
-      const result = toBoolean({} as any, defaultValue);
+      const result = to_boolean({} as any, defaultValue);
       expect(result).toBe(defaultValue);
     });
 
     it("should return true if input is 'true'", () => {
       const defaultValue = false;
-      const result = toBoolean("true", defaultValue);
+      const result = to_boolean("true", defaultValue);
       expect(result).toBe(true);
     });
 
     it("should return true if input is not lowercase", () => {
       const defaultValue = false;
-      const result = toBoolean("TrUe", defaultValue);
+      const result = to_boolean("TrUe", defaultValue);
       expect(result).toBe(true);
     });
 
     it("should return true if input is '1'", () => {
       const defaultValue = false;
-      const result = toBoolean("1", defaultValue);
+      const result = to_boolean("1", defaultValue);
       expect(result).toBe(true);
     });
 
     it("should return false if input is 'false'", () => {
       const defaultValue = true;
-      const result = toBoolean("false", defaultValue);
+      const result = to_boolean("false", defaultValue);
       expect(result).toBe(false);
     });
 
     it("should return false if input is '0'", () => {
       const defaultValue = true;
-      const result = toBoolean("0", defaultValue);
+      const result = to_boolean("0", defaultValue);
       expect(result).toBe(false);
     });
   });

--- a/src/shared/util.spec.ts
+++ b/src/shared/util.spec.ts
@@ -209,9 +209,9 @@ describe("util", () => {
   });
 
   describe("to_array", () => {
-    it("should return empty array if input is null", () => {
-      expect(to_array(null as any)).toEqual([]);
-      expect(to_array(undefined as any)).toEqual([]);
+    it("should return undefined if input is null", () => {
+      expect(to_array(null as any)).toBeUndefined();
+      expect(to_array(undefined as any)).toBeUndefined();
     });
 
     it("should return array if input is not an array", () => {

--- a/src/shared/util.spec.ts
+++ b/src/shared/util.spec.ts
@@ -1,4 +1,5 @@
 import {
+  buildTestHierarchy,
   get_i,
   sanitizeStringifiedObject,
   toBoolean,
@@ -203,6 +204,113 @@ describe("util", () => {
       const obj = { test: "test", Complex: { key: { token: "value" } } };
       const result = get_i(obj, "");
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("buildTestHierarchy", () => {
+    it("should build a test hierarchy tree", () => {
+      const objects = [
+        { name: "test1", type: "type1" },
+        { name: "test2", type: "type2" },
+        { name: "test3", type: "type3" },
+        { name: "test4", type: "type4" },
+      ];
+      const tree = buildTestHierarchy(objects, (obj) => [obj.type, obj.name]);
+      expect(tree).toEqual({
+        type1: { test1: { name: "test1", type: "type1" } },
+        type2: { test2: { name: "test2", type: "type2" } },
+        type3: { test3: { name: "test3", type: "type3" } },
+        type4: { test4: { name: "test4", type: "type4" } },
+      });
+    });
+
+    it("should build a test hierarchy tree with multiple levels", () => {
+      const objects = [
+        { name: "test1", type: "type1", group: "group1" },
+        { name: "test2", type: "type2", group: "group2" },
+        { name: "test3", type: "type3", group: "group3" },
+        { name: "test4", type: "type4", group: "group4" },
+      ];
+      const tree = buildTestHierarchy(objects, (obj) => [
+        obj.type,
+        obj.group,
+        obj.name,
+      ]);
+      expect(tree).toEqual({
+        type1: {
+          group1: { test1: { name: "test1", type: "type1", group: "group1" } },
+        },
+        type2: {
+          group2: { test2: { name: "test2", type: "type2", group: "group2" } },
+        },
+        type3: {
+          group3: { test3: { name: "test3", type: "type3", group: "group3" } },
+        },
+        type4: {
+          group4: { test4: { name: "test4", type: "type4", group: "group4" } },
+        },
+      });
+    });
+
+    it("should build a test hierarchy tree with multiple levels and multiple objects", () => {
+      const objects = [
+        { name: "test1", type: "type1", group: "group1" },
+        { name: "test2", type: "type2", group: "group2" },
+        { name: "test3", type: "type3", group: "group3" },
+        { name: "test4", type: "type4", group: "group4" },
+        { name: "test5", type: "type1", group: "group1" },
+        { name: "test6", type: "type2", group: "group2" },
+        { name: "test7", type: "type3", group: "group3" },
+        { name: "test8", type: "type4", group: "group4" },
+      ];
+      const tree = buildTestHierarchy(objects, (obj) => [
+        obj.type,
+        obj.group,
+        obj.name,
+      ]);
+      expect(tree).toEqual({
+        type1: {
+          group1: {
+            test1: { name: "test1", type: "type1", group: "group1" },
+            test5: { name: "test5", type: "type1", group: "group1" },
+          },
+        },
+        type2: {
+          group2: {
+            test2: { name: "test2", type: "type2", group: "group2" },
+            test6: { name: "test6", type: "type2", group: "group2" },
+          },
+        },
+        type3: {
+          group3: {
+            test3: { name: "test3", type: "type3", group: "group3" },
+            test7: { name: "test7", type: "type3", group: "group3" },
+          },
+        },
+        type4: {
+          group4: {
+            test4: { name: "test4", type: "type4", group: "group4" },
+            test8: { name: "test8", type: "type4", group: "group4" },
+          },
+        },
+      });
+    });
+
+    it("should handle empty objects", () => {
+      const objects: any[] = [];
+      const tree = buildTestHierarchy(objects, (obj) => []);
+      expect(tree).toEqual({});
+    });
+
+    it("should handle empty title function", () => {
+      const objects = [
+        { name: "test1", type: "type1" },
+        { name: "test2", type: "type2" },
+        { name: "test3", type: "type3" },
+        { name: "test4", type: "type4" },
+      ];
+      const tree = buildTestHierarchy(objects, (obj) => []);
+      expect(tree).toEqual({});
     });
   });
 });

--- a/src/shared/util.ts
+++ b/src/shared/util.ts
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import { C8yTestHierarchyTree } from "./types";
 
 export function safeStringify(obj: any, indent = 2) {
   let cache: any[] = [];
@@ -103,13 +104,13 @@ export function toSensitiveObjectKeyPath(
  * Gets the value of a case-insensitive key path from an object. The path is
  * assumed to be a dot-separated string. If the path is an array, it is assumed
  * to be a list of keys.
- * 
+ *
  * @example
- * geti(obj, "obj.key.token") 
+ * geti(obj, "obj.key.token")
  * geti(obj, ["obj", "key", "token"])
  * geti(obj, "obj.key[0].token")
  * geti(obj, "obj.key.0.token")
- * 
+ *
  * @param obj The object to query
  * @param keyPath The case-insensitive key path to find
  * @returns The value of the key path if found, undefined otherwise
@@ -122,4 +123,26 @@ export function get_i(
   const sensitivePath = toSensitiveObjectKeyPath(obj, keyPath);
   if (sensitivePath == null) return undefined;
   return _.get(obj, sensitivePath);
+}
+
+export function buildTestHierarchy<T>(
+  objects: T[],
+  titlefn: (obj: T) => string[]
+): C8yTestHierarchyTree<T> {
+  const tree: C8yTestHierarchyTree<T> = {};
+  objects.forEach((item) => {
+    const titles = titlefn(item);
+
+    let currentNode = tree;
+    const protectedKeys = ["__proto__", "constructor", "prototype"];
+    titles?.forEach((title, index) => {
+      if (!protectedKeys.includes(title)) {
+        if (!currentNode[title]) {
+          currentNode[title] = index === titles.length - 1 ? item : {};
+        }
+        currentNode = currentNode[title] as C8yTestHierarchyTree<T>;
+      }
+    });
+  });
+  return tree;
 }

--- a/src/shared/util.ts
+++ b/src/shared/util.ts
@@ -127,11 +127,11 @@ export function get_i(
 
 export function buildTestHierarchy<T>(
   objects: T[],
-  titlefn: (obj: T) => string[]
+  hierarchyfn: (obj: T) => string[],
 ): C8yTestHierarchyTree<T> {
   const tree: C8yTestHierarchyTree<T> = {};
   objects.forEach((item) => {
-    const titles = titlefn(item);
+    const titles = hierarchyfn(item);
 
     let currentNode = tree;
     const protectedKeys = ["__proto__", "constructor", "prototype"];

--- a/src/shared/util.ts
+++ b/src/shared/util.ts
@@ -144,22 +144,23 @@ export function to_boolean(input: string, defaultValue: boolean): boolean {
 
 export function buildTestHierarchy<T>(
   objects: T[],
-  hierarchyfn: (obj: T) => string[],
+  hierarchyfn: (obj: T) => string[] | undefined
 ): C8yTestHierarchyTree<T> {
   const tree: C8yTestHierarchyTree<T> = {};
   objects.forEach((item) => {
     const titles = hierarchyfn(item);
-
-    let currentNode = tree;
-    const protectedKeys = ["__proto__", "constructor", "prototype"];
-    titles?.forEach((title, index) => {
-      if (!protectedKeys.includes(title)) {
-        if (!currentNode[title]) {
-          currentNode[title] = index === titles.length - 1 ? item : {};
+    if (titles) {
+      let currentNode = tree;
+      const protectedKeys = ["__proto__", "constructor", "prototype"];
+      titles?.forEach((title, index) => {
+        if (!protectedKeys.includes(title)) {
+          if (!currentNode[title]) {
+            currentNode[title] = index === titles.length - 1 ? item : {};
+          }
+          currentNode = currentNode[title] as C8yTestHierarchyTree<T>;
         }
-        currentNode = currentNode[title] as C8yTestHierarchyTree<T>;
-      }
-    });
+      });
+    }
   });
   return tree;
 }

--- a/src/shared/util.ts
+++ b/src/shared/util.ts
@@ -107,10 +107,7 @@ export function toSensitiveObjectKeyPath(
  * @param keyPath The case-insensitive key path to find
  * @returns The value of the key path if found, undefined otherwise
  */
-export function get_i(
-  obj: any,
-  keyPath: string | string[]
-): any | undefined {
+export function get_i(obj: any, keyPath: string | string[]): any | undefined {
   if (obj == null || keyPath == null) return undefined;
   const sensitivePath = toSensitiveObjectKeyPath(obj, keyPath);
   if (sensitivePath == null) return undefined;
@@ -123,7 +120,7 @@ export function get_i(
  * @returns The value as an array if it is not already an array
  */
 export function to_array<T>(value: T | T[] | undefined): T[] | undefined {
-  if (value === undefined) return undefined;
+  if (value == null) return undefined;
   if (_.isArray(value)) return value;
   return [value];
 }

--- a/src/shared/util.ts
+++ b/src/shared/util.ts
@@ -125,6 +125,17 @@ export function get_i(
   return _.get(obj, sensitivePath);
 }
 
+/**
+ * Converts a value to an array. If the value is an array, it is returned as is.
+ * @param value The value to convert to an array
+ * @returns The value as an array if it is not already an array
+ */
+export function to_array<T>(value: T | T[] | undefined): T[] | undefined {
+  if (value === undefined) return undefined;
+  if (_.isArray(value)) return value;
+  return [value];
+}
+
 export function buildTestHierarchy<T>(
   objects: T[],
   hierarchyfn: (obj: T) => string[],

--- a/src/shared/util.ts
+++ b/src/shared/util.ts
@@ -27,14 +27,6 @@ export function sanitizeStringifiedObject(value: string) {
   );
 }
 
-export function toBoolean(input: string, defaultValue: boolean): boolean {
-  if (input == null || !_.isString(input)) return defaultValue;
-  const booleanString = input.toString().toLowerCase();
-  if (booleanString == "true" || booleanString === "1") return true;
-  if (booleanString == "false" || booleanString === "0") return false;
-  return defaultValue;
-}
-
 /**
  * Gets the case-sensitive path for a given case-insensitive path. The path is
  * assumed to be a dot-separated string. If the path is an array, it is assumed
@@ -134,6 +126,20 @@ export function to_array<T>(value: T | T[] | undefined): T[] | undefined {
   if (value === undefined) return undefined;
   if (_.isArray(value)) return value;
   return [value];
+}
+
+/**
+ * Converts a string value to a boolean. Supported values are "true", "false", "1", and "0".
+ * @param input The input string to convert to a boolean
+ * @param defaultValue The default value to return if the input is not a valid boolean string
+ * @returns The boolean value of the input string or the default value if the input is not a valid boolean string
+ */
+export function to_boolean(input: string, defaultValue: boolean): boolean {
+  if (input == null || !_.isString(input)) return defaultValue;
+  const booleanString = input.toString().toLowerCase();
+  if (booleanString == "true" || booleanString === "1") return true;
+  if (booleanString == "false" || booleanString === "0") return false;
+  return defaultValue;
 }
 
 export function buildTestHierarchy<T>(

--- a/test/cypress.config.ts
+++ b/test/cypress.config.ts
@@ -17,6 +17,13 @@ module.exports = defineConfig({
         }
       });
 
+      on("task", {
+        debug: (message: string) => {
+          console.log(message);
+          return null;
+        },
+      });
+
       return config;
     },
   },

--- a/test/cypress/e2e/screenshot-runner.cy.ts
+++ b/test/cypress/e2e/screenshot-runner.cy.ts
@@ -1,9 +1,12 @@
 /// <reference types="cypress" />
 
-import { ScreenshotSetup, C8yScreenshotRunner } from "cumulocity-cypress/c8yscrn";
+import {
+  ScreenshotSetup,
+  C8yScreenshotRunner,
+} from "cumulocity-cypress/c8yscrn";
 import { stubEnv } from "cypress/support/testutils";
 
-const {_ } = Cypress;
+const { _ } = Cypress;
 
 const screenshot1: ScreenshotSetup["screenshots"][0] = {
   image: "cockpit/index.html",
@@ -60,6 +63,15 @@ describe("C8yScreenshotRunner", () => {
     it("should initialize with config", () => {
       const runner = new C8yScreenshotRunner(workflow);
       expect(runner).to.be.an.instanceOf(C8yScreenshotRunner);
+      expect(runner.config).to.deep.eq(workflow);
+    });
+
+    it("should initialize with config from env", () => {
+      Cypress.env("_c8yscrnyaml", workflow);
+      const runner = new C8yScreenshotRunner();
+      expect(runner).to.be.an.instanceOf(C8yScreenshotRunner);
+      expect(runner.config).to.deep.eq(workflow);
+      Cypress.env("_c8yscrnyaml", undefined);
     });
 
     it("throws with invalid config", function (done) {
@@ -107,19 +119,19 @@ describe("C8yScreenshotRunner", () => {
 
     beforeEach(() => {
       describeStub = cy.stub(window, "describe").callsFake((title, fn) => {
-        fn(); 
+        fn();
       });
       contextStub = cy.stub(window, "context").callsFake((title, fn) => {
-        fn(); 
+        fn();
       });
       itStub = cy.stub(window, "it").callsFake((title, fn) => {
-        if (typeof fn === "function") fn(); 
+        if (typeof fn === "function") fn();
       });
       beforeEachStub = cy.stub(window, "beforeEach").callsFake((fn) => {
-        if (fn) fn(); 
+        if (fn) fn();
       });
       beforeStub = cy.stub(window, "before").callsFake((fn) => {
-        if (fn) fn(); 
+        if (fn) fn();
       });
     });
 
@@ -147,7 +159,6 @@ describe("C8yScreenshotRunner", () => {
         scrollBehavior: false,
       });
       expect(beforeEachStub).to.have.been.called;
-
     });
 
     it("should create tests for run() with tag", () => {
@@ -195,8 +206,8 @@ describe("C8yScreenshotRunner", () => {
 
       // Assert that describe, context, it, and beforeEach were called
       expect(describeStub).to.have.been.calledWith(workflow.title);
-      
-      expect(contextStub).to.have.been.calledTwice
+
+      expect(contextStub).to.have.been.calledTwice;
       expect(contextStub.getCall(0).args[0]).to.eq("cockpit");
       expect(contextStub.getCall(1).args[0]).to.eq("mytag");
 
@@ -218,7 +229,7 @@ describe("C8yScreenshotRunner", () => {
       w.global!.language = ["en", "de"];
 
       const runner = new C8yScreenshotRunner(w);
-      runner.run({tags: ["cockpit"]});  
+      runner.run({ tags: ["cockpit"] });
 
       expect(itStub).to.have.been.calledTwice;
       expect(contextStub).to.have.been.calledOnceWith("cockpit");

--- a/test/cypress/e2e/screenshot-runner.cy.ts
+++ b/test/cypress/e2e/screenshot-runner.cy.ts
@@ -1,0 +1,257 @@
+import {
+  C8yScreenshotRunner,
+  ScreenshotSetup,
+} from "cumulocity-cypress/c8yscrn";
+import { stubEnv } from "cypress/support/testutils";
+
+import _ from "lodash";
+
+describe("screenshot-runner", () => {
+  const workflow: ScreenshotSetup = {
+    title: "My Screenshots",
+    baseUrl: "https://dtmdoc.latest.stage.c8y.io",
+    global: {
+      tags: ["dtm", "c8yscrn"],
+      login: false,
+    },
+
+    screenshots: [
+      {
+        image: "dtm/asset-type/dtm-asset-type-export.png",
+        visit: "/apps/digital-twin-manager/index.html#/assetmodels",
+        tags: ["asset-type"],
+        actions: [
+          {
+            click: "$navigator.toggle",
+          },
+          {
+            highlight: {
+              selector: ".bottom-drawer .card-footer .btn-primary",
+              border: {
+                "outline-offset": "2px",
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  context("initialization", () => {
+    it("throws without config", function (done) {
+      Cypress.once("fail", (err) => {
+        expect(err.message).to.contain(
+          "C8yScreenshotRunner requires configuration."
+        );
+        done();
+      });
+      new C8yScreenshotRunner();
+    });
+
+    it("should initialize with config", () => {
+      const runner = new C8yScreenshotRunner(workflow);
+      expect(runner).to.be.an.instanceOf(C8yScreenshotRunner);
+    });
+
+    it("throws with invalid config", function (done) {
+      Cypress.once("fail", (err) => {
+        expect(err.message).to.contain("Invalid config file.");
+        done();
+      });
+      new C8yScreenshotRunner({} as ScreenshotSetup);
+    });
+
+    it("should register action handlers", () => {
+      const runner = new C8yScreenshotRunner(workflow);
+      expect(runner.actionHandlers).to.have.property("click");
+      expect(runner.actionHandlers).to.have.property("text");
+      expect(runner.actionHandlers).to.have.property("screenshot");
+      expect(runner.actionHandlers).to.have.property("fileUpload");
+      expect(runner.actionHandlers).to.have.property("wait");
+      expect(runner.actionHandlers).to.have.property("blur");
+      expect(runner.actionHandlers).to.have.property("focus");
+      expect(runner.actionHandlers).to.have.property("scrollTo");
+      expect(runner.actionHandlers).to.have.property("highlight");
+    });
+
+    it("should register highlight action handler when enabled", () => {
+      stubEnv({ _c8yscrnHighlight: true });
+
+      const runner = new C8yScreenshotRunner(workflow);
+      expect(runner.actionHandlers).to.have.property("highlight");
+    });
+
+    it("should not register highlight action handler when disabled", () => {
+      stubEnv({ _c8yscrnHighlight: false });
+
+      const runner = new C8yScreenshotRunner(workflow);
+      expect(runner.actionHandlers).to.not.have.property("highlight");
+    });
+  });
+
+  context("runSuite", () => {
+    beforeEach(() => {
+      cy.spy(global, "describe").as("describeSpy");
+      cy.spy(global, "context").as("contextSpy");
+      cy.spy(global, "it").as("itSpy");
+    });
+
+    it("should create Cypress test suite structure from workflow", () => {
+      const runner = new C8yScreenshotRunner(workflow);
+      runner.runSuite();
+
+      cy.get<sinon.SinonSpy>("@describeSpy").should(
+        "be.calledWith",
+        "My Screenshots"
+      );
+      cy.get<sinon.SinonSpy>("@contextSpy").should("be.calledTwice");
+      cy.get<sinon.SinonSpy>("@itSpy").should(
+        "be.calledWith",
+        "dtm-asset-type-export.png (en)",
+        { tags: ["asset-type"], scrollBehavior: false }
+      );
+    });
+
+    it("should create Cypress test suite structure from workflow with multiple languages", () => {
+      const w = { ...workflow, ...{ global: { language: ["en", "de"] } } };
+      const runner = new C8yScreenshotRunner(w);
+      runner.runSuite();
+
+      // Verify the test structure was created correctly
+      cy.get<sinon.SinonSpy>("@describeSpy").should(
+        "be.calledWith",
+        "My Screenshots"
+      );
+      cy.get<sinon.SinonSpy>("@contextSpy").should("be.calledTwice");
+      cy.get<sinon.SinonSpy>("@itSpy").should("be.calledTwice");
+
+      cy.get<sinon.SinonSpy>("@itSpy").should(
+        "be.calledWith",
+        "dtm-asset-type-export.png (en)",
+        { tags: ["asset-type"], scrollBehavior: false }
+      );
+      cy.get<sinon.SinonSpy>("@itSpy").should(
+        "be.calledWith",
+        "dtm-asset-type-export.png (de)",
+        { tags: ["asset-type"], scrollBehavior: false }
+      );
+    });
+  });
+
+  context.skip("run", () => {
+    const screenshots = _.concat(workflow.screenshots, {
+      image: "cockpit/index.png",
+      visit: "/apps/cockpit/index.html#",
+      tags: ["cockpit"],
+      actions: [
+        {
+          click: "$navigator.toggle",
+        },
+        {
+          highlight: {
+            selector: ".bottom-drawer .card-footer .btn-primary",
+            border: {
+              "outline-offset": "2px",
+            },
+          },
+        },
+      ],
+    });
+
+    const workflowWith2Objects = _.cloneDeep(workflow);
+    workflowWith2Objects.screenshots = screenshots;
+
+    let describeStub: sinon.SinonStub;
+    let contextStub: sinon.SinonStub;
+    let itStub: sinon.SinonStub;
+    let beforeEachStub: sinon.SinonStub;
+    let beforeStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      // Create chainable stubs for all Mocha functions
+      describeStub = cy
+        .stub(global, "describe")
+        .callsFake(function (name, fn) {
+          fn?.();
+          return describeStub; // Return the stub to allow chaining
+        })
+        .as("describeSpy");
+
+      contextStub = cy
+        .stub(global, "context")
+        .callsFake(function (name, fn) {
+          fn?.();
+          return contextStub;
+        })
+        .as("contextSpy");
+
+      itStub = cy
+        .stub(global, "it")
+        .callsFake(function (name, options, fn) {
+          // Handle the case where options is omitted
+          if (typeof options === "function") {
+            fn = options;
+          }
+          return itStub;
+        })
+        .as("itSpy");
+
+      beforeEachStub = cy.stub(global, "beforeEach").as("beforeEachSpy");
+      beforeStub = cy.stub(global, "before").as("beforeSpy");
+    });
+
+    afterEach(() => {
+      describeStub.restore();
+      contextStub.restore();
+      itStub.restore();
+      beforeEachStub.restore();
+      beforeStub.restore();
+    });
+
+    it.skip("should filter tests when run() is called with options", () => {
+      const runner = new C8yScreenshotRunner(workflowWith2Objects);
+      runner.run({ tags: ["cockpit"] });
+
+      cy.get("@describeSpy").should("not.be.called");
+      cy.get("@contextSpy").should("be.calledOnceWith", "cockpit");
+      cy.get("@beforeEachSpy").should("be.calledTwice"); // context + it
+      cy.get("@itSpy").should("be.calledOnceWith", "index.png (en)", {
+        tags: ["cockpit"],
+        scrollBehavior: false,
+      });
+
+      cy.get("@itSpy").should(
+        "not.be.calledWith",
+        "dtm-asset-type-export.png (en)"
+      );
+    });
+  });
+});
+
+// function getCurrentTestId(): string {
+//   try {
+//     // Get current test (safely)
+//     const cypressAny = Cypress as any;
+
+//     const currentTest =
+//       Cypress.currentTest ||
+//       Cypress.mocha?.getRunner()?.test ||
+//       Cypress.state("test");
+
+//     // Check if titlePath exists and is a function
+//     if (currentTest && typeof currentTest.titlePath === "function") {
+//       return currentTest.titlePath().join(" -- ");
+//     } else if (currentTest && currentTest.fullTitle) {
+//       // Fallback to fullTitle if available
+//       return typeof currentTest.fullTitle === "function"
+//         ? currentTest.fullTitle()
+//         : currentTest.fullTitle;
+//     }
+
+//     // Final fallback
+//     return "unknown-test-id";
+//   } catch (e) {
+//     console.warn("Error getting test ID:", e);
+//     return "error-test-id";
+//   }
+// }


### PR DESCRIPTION
Allow more flexible integration of `C8yScreenshotRunner` into Cypress projects. `C8yScreenshotRunner` now supports selecting the screenshot workflows to run via options argument and use within existing cypress tests.

```typescript
const runner = new C8yScreenshotRunner();

describe("Cockpit tests", () => {
  beforeEach(() => {
     // setup, configure interceptions, etc
  });

  // run with tags, image or titles filter 
  runner.run({ tags: ["cockpit"] });
});

describe("DTM tests", () => {
  beforeEach(() => {
     // setup, configure interceptions, etc
  });

  runner.run({ titles: ["dtm", "assets", "import"] });
})
```