### PR TITLE
fix(pact-runner): Enabled multi-auth support in pact runner and fixed expected failure of request

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -124,7 +124,12 @@ export function configureC8yPlugin(
   function getPact(pact: string): C8yPact | null {
     log(`getPact() - ${pact}`);
     validateId(pact);
-    return adapter?.loadPact(pact) || null;
+    try {
+      return adapter?.loadPact(pact) || null;
+    } catch (e) {
+      log(`getPact() - ${e}`);
+      return null;
+    }
   }
 
   function removePact(pact: string): boolean {

--- a/src/shared/c8ypact/adapter/fileadapter.ts
+++ b/src/shared/c8ypact/adapter/fileadapter.ts
@@ -100,7 +100,9 @@ export class C8yPactDefaultFileAdapter implements C8yPactFileAdapter {
     if (fs.existsSync(file)) {
       const pact = fs.readFileSync(file, "utf-8");
       log(`loadPact() - ${file} loaded`);
-      return JSON.parse(pact);
+      const json = JSON.parse(pact);
+      log(`loadPact() - parsed as json`);
+      return json || null;
     } else {
       log(`loadPact() - ${file} does not exist`);
     }

--- a/src/shared/c8ypact/matcher.ts
+++ b/src/shared/c8ypact/matcher.ts
@@ -267,7 +267,7 @@ export class C8yPactBodyMatcher extends C8yDefaultPactMatcher {
     this.addPropertyMatcher("next", new C8yIgnoreMatcher());
     this.addPropertyMatcher("self", new C8yIgnoreMatcher());
     this.addPropertyMatcher("password", new C8yIgnoreMatcher());
-    this.addPropertyMatcher("owner", new C8yIgnoreMatcher());
+    this.addPropertyMatcher("owner", new C8ySameTypeMatcher());
     this.addPropertyMatcher("tenantId", new C8yIgnoreMatcher());
     this.addPropertyMatcher(
       "lastPasswordChange",

--- a/src/shared/util.spec.ts
+++ b/src/shared/util.spec.ts
@@ -1,6 +1,7 @@
 import {
   get_i,
   sanitizeStringifiedObject,
+  to_array,
   toBoolean,
   toSensitiveObjectKeyPath,
 } from "./util";
@@ -203,6 +204,28 @@ describe("util", () => {
       const obj = { test: "test", Complex: { key: { token: "value" } } };
       const result = get_i(obj, "");
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("to_array", () => {
+    it("should return empty array if input is null", () => {
+      expect(to_array(null as any)).toEqual([]);
+      expect(to_array(undefined as any)).toEqual([]);
+    });
+
+    it("should return array if input is not an array", () => {
+      const result = to_array("test" as any);
+      expect(result).toEqual(["test"]);
+    });
+
+    it("should return array if input is an array", () => {
+      const result = to_array(["test"]);
+      expect(result).toEqual(["test"]);
+    });
+
+    it("should return array if input is an object", () => {
+      const result = to_array({ test: "test" });
+      expect(result).toEqual([{ test: "test" }]);
     });
   });
 });

--- a/src/shared/util.ts
+++ b/src/shared/util.ts
@@ -123,3 +123,13 @@ export function get_i(
   if (sensitivePath == null) return undefined;
   return _.get(obj, sensitivePath);
 }
+
+/**
+ * Maps a value to an array if it is not already an array.
+ * @param value The value to map to an array
+ * @returns The value as an array
+ */
+export function to_array<T>(value: T | T[]): T[] {
+  if (value == null) return [];
+  return _.isArray(value) ? value : [value];
+}


### PR DESCRIPTION
The pact-runner now allows providing multiple auth user aliases to rerun the same pact request multiple times with different users. User for permission testing assuming the same response for different users with different roles / permissions. Also a bug has been fixed to run failing requests (status >= 400).