### PR TITLE
feat(c8ypact): Allow loading yaml and js files using C8yPactDefaultFileAdapter

### DIFF
--- a/packages/pact-runner/cypress.config.ts
+++ b/packages/pact-runner/cypress.config.ts
@@ -17,8 +17,11 @@ module.exports = defineConfig({
         config.env.grepTags = config.env.C8Y_PACT_RUNNER_TAGS;
       }
 
-      const adapter = new C8yPactDefaultFileAdapter(`${fixture}`);
-      config.env._pacts = adapter.readJsonFiles();
+      const javascriptEnabled = config.env.C8Y_PACT_RUNNER_JS_ENABLED ?? false;
+      const adapter = new C8yPactDefaultFileAdapter(`${fixture}`, {
+        enableJavaScript: javascriptEnabled,
+      });
+      config.env._pacts = adapter.readPactFiles();
 
       const baseUrl =
         config.env.baseUrl || config.env.C8Y_PACT_RUNNER_BASEURL || null;

--- a/src/shared/c8ypact/adapter/fileadapter-js.spec.ts
+++ b/src/shared/c8ypact/adapter/fileadapter-js.spec.ts
@@ -1,0 +1,117 @@
+/// <reference types="jest" />
+
+import * as path from "path";
+import { C8yPactDefaultFileAdapter } from "./fileadapter";
+
+describe("C8yPactFileAdapter - js loading", () => {
+  const fixturesPath = path.join(__dirname, "../../../../test/fixtures/js");
+
+  describe("js enabled", () => {
+    const adapterOptions = { enableJavaScript: true };
+
+    it("should load JavaScript pact file (.js)", () => {
+      const adapter = new C8yPactDefaultFileAdapter(
+        fixturesPath,
+        adapterOptions
+      );
+      const pact = adapter.loadPact("jstest");
+      expect(pact).toBeDefined();
+      expect(pact?.id).toBe("jstest");
+      expect(pact?.info.id).toBe("jstest");
+      expect(pact?.info.tenant).toBe("test-tenant");
+      expect(pact?.records).toHaveLength(1);
+      expect(pact?.records[0].request.method).toBe("GET");
+    });
+
+    it("should load CommonJS pact file (.cjs)", () => {
+      const adapter = new C8yPactDefaultFileAdapter(
+        fixturesPath,
+        adapterOptions
+      );
+      const pact = adapter.loadPact("cjstest");
+      expect(pact).toBeDefined();
+      expect(pact?.id).toBe("cjstest");
+      expect(pact?.info.id).toBe("cjstest");
+      expect(pact?.info.tenant).toBe("test-tenant");
+      expect(pact?.records).toHaveLength(1);
+      expect(pact?.records[0].request.method).toBe("POST");
+    });
+
+    it("should include JavaScript and CJS files in loadPacts()", () => {
+      const adapter = new C8yPactDefaultFileAdapter(
+        fixturesPath,
+        adapterOptions
+      );
+      const pacts = adapter.loadPacts();
+      expect(pacts).toBeDefined();
+      expect(pacts["jstest"]).toBeDefined();
+      expect(pacts["jstest"].info.tenant).toBe("test-tenant");
+      expect(pacts["cjstest"]).toBeDefined();
+      expect(pacts["cjstest"].info.tenant).toBe("test-tenant");
+    });
+
+    it("should correctly detect JS and CJS file existence with pactExists()", () => {
+      const adapter = new C8yPactDefaultFileAdapter(
+        fixturesPath,
+        adapterOptions
+      );
+      expect(adapter.pactExists("jstest")).toBe(true);
+      expect(adapter.pactExists("cjstest")).toBe(true);
+      expect(adapter.pactExists("nonexistent")).toBe(false);
+    });
+  });
+
+  describe("js disabled", () => {
+    it("should NOT load JavaScript pact file (.js)", () => {
+      const adapter = new C8yPactDefaultFileAdapter(fixturesPath);
+      const pact = adapter.loadPact("jstest");
+      expect(pact).toBeNull();
+    });
+
+    it("should NOT load CommonJS pact file (.cjs)", () => {
+      const adapter = new C8yPactDefaultFileAdapter(fixturesPath);
+      const pact = adapter.loadPact("cjstest");
+      expect(pact).toBeNull();
+    });
+
+    it("should NOT include JavaScript or CJS files in loadPacts()", () => {
+      const adapter = new C8yPactDefaultFileAdapter(fixturesPath);
+      const pacts = adapter.loadPacts();
+      expect(pacts).toBeDefined();
+      expect(pacts["jstest"]).toBeUndefined();
+      expect(pacts["cjstest"]).toBeUndefined();
+      // Assuming there might be other file types like json, check it's not empty if they exist
+      // For this specific test file, if only JS files are present, it might be empty.
+      // If a json file (e.g. simpletest.json) was in fixturesPath, it should be loaded.
+    });
+
+    it("should NOT detect JS or CJS file existence with pactExists()", () => {
+      const adapter = new C8yPactDefaultFileAdapter(fixturesPath);
+      expect(adapter.pactExists("jstest")).toBe(false);
+      expect(adapter.pactExists("cjstest")).toBe(false);
+      expect(adapter.pactExists("nonexistent")).toBe(false);
+    });
+  });
+
+  describe("when JavaScript is explicitly disabled", () => {
+    const adapterOptions = { enableJavaScript: false };
+
+    it("should NOT load JavaScript pact file (.js)", () => {
+      const adapter = new C8yPactDefaultFileAdapter(
+        fixturesPath,
+        adapterOptions
+      );
+      const pact = adapter.loadPact("jstest");
+      expect(pact).toBeNull();
+    });
+
+    it("should NOT load CommonJS pact file (.cjs)", () => {
+      const adapter = new C8yPactDefaultFileAdapter(
+        fixturesPath,
+        adapterOptions
+      );
+      const pact = adapter.loadPact("cjstest");
+      expect(pact).toBeNull();
+    });
+  });
+});

--- a/src/shared/c8ypact/adapter/fileadapter.spec.ts
+++ b/src/shared/c8ypact/adapter/fileadapter.spec.ts
@@ -27,6 +27,9 @@ describe("C8yPactDefaultFileAdapter", () => {
             id: "simpletest",
           })
         ),
+        "yamltest.yaml": Buffer.from(
+          "info:\n  id: yamltest\nrecords: []\nid: yamltest"
+        ),
       },
     });
   });
@@ -66,6 +69,35 @@ describe("C8yPactDefaultFileAdapter", () => {
       const adapter = new C8yPactDefaultFileAdapter(path.join(CWD, "23"));
       const pacts = adapter.loadPacts();
       expect(pacts).toEqual({});
+    });
+
+    it("should load json pact file", () => {
+      const adapter = new C8yPactDefaultFileAdapter(
+        path.join("cypress", "test", "c8ypact")
+      );
+      const pact = adapter.loadPact("simpletest");
+      expect(pact).toBeDefined();
+      expect(pact?.id).toBe("simpletest");
+      expect(pact?.info.id).toBe("simpletest");
+    });
+
+    it("should load yaml pact file", () => {
+      const adapter = new C8yPactDefaultFileAdapter(
+        path.join("cypress", "test", "c8ypact")
+      );
+      const pact = adapter.loadPact("yamltest");
+      expect(pact).toBeDefined();
+      expect(pact?.id).toBe("yamltest");
+      expect(pact?.info.id).toBe("yamltest");
+    });
+
+    it("should correctly check if pact exists with different file extensions", () => {
+      const adapter = new C8yPactDefaultFileAdapter(
+        path.join("cypress", "test", "c8ypact")
+      );
+      expect(adapter.pactExists("simpletest")).toBe(true);
+      expect(adapter.pactExists("yamltest")).toBe(true);
+      expect(adapter.pactExists("nonexistent")).toBe(false);
     });
   });
 

--- a/src/shared/c8ypact/adapter/fileadapter.ts
+++ b/src/shared/c8ypact/adapter/fileadapter.ts
@@ -58,14 +58,14 @@ export interface C8yPactFileAdapter {
 const log = debug("c8y:fileadapter");
 
 /**
- * Default implementation of C8yPactFileAdapter which loads and saves C8yPact objects 
- * Provide location of the files using folder option. Default location is 
+ * Default implementation of C8yPactFileAdapter which loads and saves C8yPact objects
+ * Provide location of the files using folder option. Default location is
  * cypress/fixtures/c8ypact folder.
- * 
+ *
  * This adapter supports loading of JSON and YAML pact files (.json, .yaml, .yml). When
  * saviing pact files, it saves them as JSON files (.json).
- * 
- * By using C8yPactAdapterOptions you can enable loading of JavaScript pact files (.js, .cjs). 
+ *
+ * By using C8yPactAdapterOptions you can enable loading of JavaScript pact files (.js, .cjs).
  * Use with caution, as this can lead to security issues if the files are not trusted.
  */
 export class C8yPactDefaultFileAdapter implements C8yPactFileAdapter {
@@ -202,6 +202,21 @@ export class C8yPactDefaultFileAdapter implements C8yPactFileAdapter {
     }
   }
 
+  readPactFiles(): string[] {
+    log(`readPactFiles() - ${this.folder}`);
+    if (!this.folder || !fs.existsSync(this.folder)) {
+      log(`readPactFiles() - ${this.folder} does not exist`);
+      return [];
+    }
+    const pacts = this.loadPactObjects();
+    return pacts.map((pact) => {
+      return safeStringify(pact);
+    });
+  }
+
+  /**
+   * @deprecated Use readPactFiles() instead.
+   */
   readJsonFiles(): string[] {
     log(`readJsonFiles() - ${this.folder}`);
     if (!this.folder || !fs.existsSync(this.folder)) {

--- a/src/shared/c8ypact/adapter/fileadapter.ts
+++ b/src/shared/c8ypact/adapter/fileadapter.ts
@@ -3,12 +3,18 @@ import * as path from "path";
 import * as glob from "glob";
 import debug from "debug";
 import { C8yPact, C8yPactSaveKeys, pactId } from "../c8ypact";
+import * as yaml from "yaml";
 
 import { safeStringify } from "../../util";
 
 import lodash1 from "lodash";
 import * as lodash2 from "lodash";
 const _ = lodash1 || lodash2;
+
+export interface C8yPactAdapterOptions {
+  /** Enable loading of JavaScript pact files (.js, .cjs). Defaults to false. */
+  enableJavaScript?: boolean;
+}
 
 /**
  * Using C8yPactFileAdapter you can implement your own adapter to load and save pacts using any format you want.
@@ -57,10 +63,18 @@ const log = debug("c8y:fileadapter");
  */
 export class C8yPactDefaultFileAdapter implements C8yPactFileAdapter {
   folder: string;
-  constructor(folder: string) {
+  private enabledExtensions: string[];
+
+  constructor(folder: string, options?: C8yPactAdapterOptions) {
     this.folder = path.isAbsolute(folder)
       ? folder
       : this.toAbsolutePath(folder);
+
+    this.enabledExtensions = [".json", ".yaml", ".yml"];
+    if (options?.enableJavaScript) {
+      this.enabledExtensions.push(".js", ".cjs");
+    }
+    log(`Initialized with enabled extensions: ${this.enabledExtensions.join(", ")}`);
   }
 
   description(): string {
@@ -72,10 +86,10 @@ export class C8yPactDefaultFileAdapter implements C8yPactFileAdapter {
   }
 
   loadPacts(): { [key: string]: C8yPact } {
-    const jsonFiles = this.loadPactObjects();
-    log(`loadPacts() - ${jsonFiles.length} pact files from ${this.folder}`);
+    const pactObjects = this.loadPactObjects();
+    log(`loadPacts() - ${pactObjects.length} pact files from ${this.folder}`);
 
-    return jsonFiles.reduce((acc, obj) => {
+    return pactObjects.reduce((acc: { [key: string]: C8yPact }, obj) => {
       if (!obj?.info?.id) return acc;
       acc[obj.info.id] = obj;
       return acc;
@@ -96,21 +110,40 @@ export class C8yPactDefaultFileAdapter implements C8yPactFileAdapter {
       return null;
     }
 
-    const file = path.join(this.folder, `${pId}.json`);
-    if (fs.existsSync(file)) {
-      const pact = fs.readFileSync(file, "utf-8");
-      log(`loadPact() - ${file} loaded`);
-      const json = JSON.parse(pact);
-      log(`loadPact() - parsed as json`);
-      return json || null;
-    } else {
-      log(`loadPact() - ${file} does not exist`);
+    // Try to find the file with different supported extensions
+    const extensions = this.enabledExtensions;
+    let loadedPact = null;
+
+    for (const ext of extensions) {
+      const file = path.join(this.folder, `${pId}${ext}`);
+      if (fs.existsSync(file)) {
+        try {
+          loadedPact = this.loadPactFromFile(file);
+          if (loadedPact) {
+            log(`loadPact() - ${file} loaded successfully`);
+            return loadedPact;
+          }
+        } catch (error) {
+          log(`loadPact() - error loading ${file}: ${error}`);
+        }
+      }
     }
+
+    log(`loadPact() - no valid pact file found for id ${pId}`);
     return null;
   }
 
   pactExists(id: string): boolean {
-    return fs.existsSync(path.join(this.folder, `${pactId(id)}.json`));
+    const pId = pactId(id);
+    const extensions = this.enabledExtensions;
+
+    for (const ext of extensions) {
+      if (fs.existsSync(path.join(this.folder, `${pId}${ext}`))) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   savePact(pact: C8yPact | Pick<C8yPact, C8yPactSaveKeys>): void {
@@ -188,8 +221,91 @@ export class C8yPactDefaultFileAdapter implements C8yPactFileAdapter {
   }
 
   protected loadPactObjects() {
-    const pacts = this.readJsonFiles();
-    return pacts.map((pact) => JSON.parse(pact));
+    log(`loadPactObjects() - ${this.folder}`);
+    if (!this.folder || !fs.existsSync(this.folder)) {
+      log(`loadPactObjects() - ${this.folder} does not exist`);
+      return [];
+    }
+
+    // Find all files with supported extensions
+    const extensions = this.enabledExtensions;
+    const patterns = extensions.map((ext) => path.join(this.folder, `*${ext}`));
+    const allFiles = patterns.flatMap((pattern) => glob.sync(pattern));
+
+    log(
+      `loadPactObjects() - reading ${allFiles.length} files from ${this.folder}`
+    );
+
+    // Load and parse each file based on its extension
+    const pactObjects = allFiles
+      .map((file) => {
+        try {
+          return this.loadPactFromFile(file);
+        } catch (error) {
+          log(`loadPactObjects() - error loading ${file}: ${error}`);
+          return null;
+        }
+      })
+      .filter(Boolean);
+
+    log(`loadPactObjects() - loaded ${pactObjects.length} valid pact objects`);
+    return pactObjects;
+  }
+
+  protected loadPactFromFile(filePath: string): C8yPact | null {
+    if (!fs.existsSync(filePath)) {
+      log(`loadPactFromFile() - file does not exist: ${filePath}`);
+      return null;
+    }
+
+    const extension = path.extname(filePath).toLowerCase();
+
+    // Check if the extension is enabled
+    if (!this.enabledExtensions.includes(extension)) {
+      log(
+        `loadPactFromFile() - file extension ${extension} is not enabled for loading: ${filePath}`
+      );
+      return null;
+    }
+
+    const content = fs.readFileSync(filePath, "utf-8");
+
+    try {
+      // Handle different file formats
+      if (extension === ".json") {
+        // Load JSON file
+        return JSON.parse(content);
+      } else if (extension === ".yaml" || extension === ".yml") {
+        // Load YAML file
+        return yaml.parse(content) as C8yPact;
+      } else if (extension === ".js" || extension === ".cjs") {
+        // CommonJS modules (.js, .cjs) can use require
+        const absolutePath = path.isAbsolute(filePath)
+          ? filePath
+          : path.resolve(process.cwd(), filePath);
+        try {
+          // Clear cache if needed
+          if (require.cache && require.cache[require.resolve(absolutePath)]) {
+            delete require.cache[require.resolve(absolutePath)];
+          }
+
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          const pactModule = require(absolutePath);
+          return pactModule.default || pactModule;
+        } catch (error) {
+          log(
+            `loadPactFromFile() - error requiring module file ${absolutePath}: ${error}`
+          );
+          return null;
+        }
+      }
+
+      log(`loadPactFromFile() - unsupported file extension: ${extension}`);
+      return null;
+    } catch (error) {
+      log(`loadPactFromFile() - error parsing file ${filePath}: ${error}`);
+      return null;
+    }
   }
 
   protected createFolderRecursive(f: string) {

--- a/test/fixtures/js/cjstest.cjs
+++ b/test/fixtures/js/cjstest.cjs
@@ -1,0 +1,18 @@
+
+const baseUrl = 'https://example.com';
+
+// A CommonJS module pact file
+module.exports = {
+  info: {
+    id: 'cjstest',
+    tenant: 'test-tenant',
+    baseUrl,
+  },
+  records: [
+    {
+      request: { method: 'POST', url: '/api/cjs' },
+      response: { status: 201 }
+    }
+  ],
+  id: 'cjstest'
+};

--- a/test/fixtures/js/jstest.js
+++ b/test/fixtures/js/jstest.js
@@ -1,0 +1,18 @@
+
+const baseUrl = 'https://example.com';
+
+// A simple JavaScript pact file
+module.exports = {
+  info: { 
+    id: 'jstest',
+    tenant: 'test-tenant',
+    baseUrl,
+  },
+  records: [
+    {
+      request: { method: 'GET', url: '/api/test' },
+      response: { status: 200 }
+    }
+  ],
+  id: 'jstest'
+};


### PR DESCRIPTION
`C8yPactDefaultFileAdapter` now supports `yaml` as well as `(c)js` loading of `C8yPact` files. Using Javascript is useful if you are using `C8yPact` files for API testing to dynamically create records and reduce duplication required in `json`. To enable Javascript, `C8yPactDefaultFileAdapter` requires the `enableJavaScript` config option to be enabled. By default, Javascript support is disabled.

```typescript
import { defineConfig } from 'cypress';
import { configureC8yPlugin } from 'cumulocity-cypress/plugin';

module.exports = defineConfig({
  e2e: {
    setupNodeEvents(on, config) {
      const adapter = new C8yPactDefaultFileAdapter("/my/custom/pact/location", {
        enableJavaScript: true,
      });
      configureC8yPlugin(on, config, {
        pactAdapter: adapter,
      });
      return config;
    },
  },
});
```