### PR TITLE
feat(c8ypact): Allow use of $ref references in C8yPact documents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^12.0.2",
         "@cypress/grep": "^4.1.0",
         "ajv": "^8.12.0",
         "ajv-formats": "^3.0.1",
@@ -137,6 +138,23 @@
       "peerDependencies": {
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-12.0.2.tgz",
+      "integrity": "sha512-SoZWqQz4YMKdw4kEMfG5w6QAy+rntjsoAT1FtvZAnVEnCR4uy9YSuDBNoVAFHgzSz0dJbISLLCSrGR2Zd7bcvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2065,6 +2083,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
     },
     "node_modules/@jsonjoy.com/base64": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     }
   },
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": "^12.0.2",
     "@cypress/grep": "^4.1.0",
     "ajv": "^8.12.0",
     "ajv-formats": "^3.0.1",

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -33,6 +33,7 @@ import {
 } from "../lib/screenshots/types";
 import { loadConfigFile } from "../c8yscrn/helper";
 import { C8yBaseUrl } from "../shared/types";
+import { resolvePact } from "cumulocity-cypress/shared/c8ypact/c8yresolver";
 
 export { C8yPactFileAdapter, C8yPactDefaultFileAdapter };
 export { readYamlFile, loadConfigFile } from "../c8yscrn/helper";
@@ -262,6 +263,7 @@ export function configureC8yPlugin(
       "c8ypact:save": savePact,
       "c8ypact:get": getPact,
       "c8ypact:remove": removePact,
+      "c8ypact:resolve": resolvePact,
       "c8ypact:http:start": startHttpController,
       "c8ypact:http:stop": stopHttpController,
       "c8ypact:oauthLogin": login,

--- a/src/shared/c8ypact/c8yresolver.spec.ts
+++ b/src/shared/c8ypact/c8yresolver.spec.ts
@@ -1,0 +1,277 @@
+// @ts-nocheck
+/// <reference types="jest" />
+
+import { resolvePact } from "./c8yresolver";
+import { vol } from "memfs"; // Import vol
+
+import path from "path"; 
+import fs from "fs"; 
+import url from "url";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+jest.mock("fs", () => require("memfs").fs);
+
+const CWD = "/home/user";
+
+describe("resolvePact", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("internal $refs", () => {
+    it("should resolve a simple internal $ref", async () => {
+      const doc = {
+        definitions: {
+          simple: { message: "Hello" },
+        },
+        instance: { $ref: "#/definitions/simple" },
+      };
+
+      const resolved = await resolvePact(doc);
+      expect(resolved.instance.message).toBe("Hello");
+    });
+
+    it("should resolve a parameterized $ref with object definition", async () => {
+      const doc = {
+        definitions: {
+          parameterizedDef: {
+            message: "Hello {{name}}!",
+            details: {
+              value: "The value is {{value}}.",
+            },
+          },
+        },
+        instance: {
+          // Using #/ for internal refs as c8y:/ is normalized to #/
+          $ref: "#/definitions/parameterizedDef?name=World&value=42",
+        },
+      };
+      const resolved = await resolvePact(doc);
+      expect(resolved.instance.message).toBe("Hello World!");
+      expect(resolved.instance.details.value).toBe("The value is 42.");
+    });
+
+    it("should resolve a parameterized $ref with multiple placeholders in one string", async () => {
+      const doc = {
+        definitions: {
+          multiParamDef: {
+            greeting: "Hi {{firstName}} {{lastName}}, welcome!",
+          },
+        },
+        usage: {
+          $ref: "#/definitions/multiParamDef?firstName=John&lastName=Doe",
+        },
+      };
+      const resolved = await resolvePact(doc);
+      expect(resolved.usage.greeting).toBe("Hi John Doe, welcome!");
+    });
+
+    it("should resolve a parameterized $ref with an array in the definition", async () => {
+      const doc = {
+        definitions: {
+          arrayDef: {
+            items: [
+              "Item {{id}}",
+              { fixed: "Value", dynamic: "Status: {{status}}" },
+            ],
+          },
+        },
+        data: {
+          $ref: "#/definitions/arrayDef?id=123&status=active",
+        },
+      };
+      const resolved = await resolvePact(doc);
+      expect(resolved.data.items[0]).toBe("Item 123");
+      expect(resolved.data.items[1].fixed).toBe("Value");
+      expect(resolved.data.items[1].dynamic).toBe("Status: active");
+    });
+
+    it("should convert parameters to strings during replacement", async () => {
+      const doc = {
+        definitions: {
+          typedDef: {
+            numeric: "Number: {{numVal}}",
+            boolean: "Boolean: {{boolVal}}",
+          },
+        },
+        result: {
+          $ref: "#/definitions/typedDef?numVal=100&boolVal=true",
+        },
+      };
+      const resolved = await resolvePact(doc);
+      // Current implementation stringifies parameters
+      expect(resolved.result.numeric).toBe("Number: 100");
+      expect(resolved.result.boolean).toBe("Boolean: true");
+    });
+
+    it("should resolve parameterized $ref whose definition contains a simple $ref", async () => {
+      const doc = {
+        definitions: {
+          primitive: "A simple string value.",
+          complexDef: {
+            message: "Parameterized: {{val}}",
+            internalRef: { $ref: "#/definitions/primitive" },
+          },
+        },
+        output: {
+          $ref: "#/definitions/complexDef?val=TestValue",
+        },
+      };
+      const resolved = await resolvePact(doc);
+      expect(resolved.output.message).toBe("Parameterized: TestValue");
+      expect(resolved.output.internalRef).toBe("A simple string value.");
+    });
+
+    it("should leave placeholders if no parameters are provided in $ref", async () => {
+      const doc = {
+        definitions: {
+          needsParams: { message: "Data: {{data}}" },
+        },
+        instance: { $ref: "#/definitions/needsParams" }, // No query parameters
+      };
+      const resolved = await resolvePact(doc);
+      // The custom resolver runs, but params object is empty.
+      expect(resolved.instance.message).toBe("Data: {{data}}");
+    });
+
+    it("should leave placeholders if $ref parameters do not match", async () => {
+      const doc = {
+        definitions: {
+          specificPlaceholders: { message: "Value: {{value}}" },
+        },
+        instance: {
+          $ref: "#/definitions/specificPlaceholders?otherParam=irrelevant",
+        },
+      };
+      const resolved = await resolvePact(doc);
+      expect(resolved.instance.message).toBe("Value: {{value}}");
+    });
+
+    it("should handle $ref to a definition that is a parameterized string", async () => {
+      const doc = {
+        definitions: {
+          primitiveTemplate: "Value: {{val}}",
+        },
+        instance: {
+          $ref: "#/definitions/primitiveTemplate?val=Test",
+        },
+      };
+      const resolved = await resolvePact(doc);
+      // With the new three-stage approach, the string should be correctly parameterized.
+      expect(resolved.instance).toBe("Value: Test");
+    });
+  });
+  // --- Tests for External File References ---
+  describe("external file $refs", () => {
+    beforeEach(() => {
+      // Ensure process.cwd() is mocked for each test in this suite
+      jest.spyOn(process, "cwd").mockReturnValue(CWD);
+
+      // Setup memfs volume. Files will be created relative to CWD.
+      // e.g., /home/user/test/fixtures/externalDef.json
+      vol.fromNestedJSON({
+        [CWD]: {
+          // Base path for the structure
+          test: {
+            fixtures: {
+              "externalDef.json": JSON.stringify({
+                simpleExternal: {
+                  message: "Hello from external file!",
+                },
+              }),
+              "externalParameterizedDef.json": JSON.stringify({
+                parameterizedExternal: {
+                  greeting: "Greetings, {{name}}, from an external source!",
+                  detail: "Your value is {{value}}.",
+                },
+              }),
+              "externalRefToExternal.json": JSON.stringify({
+                externalContainer: {
+                  name: "Container for another external def",
+                  containedDef: { $ref: "./externalDef.json#/simpleExternal" }, 
+                },
+              }),
+            },
+          },
+        },
+      });
+    });
+
+    afterEach(() => {
+      vol.reset();
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("should directly read and verify content of a mocked JSON file", () => {
+      const filePath = path.join(CWD, "test/fixtures", "externalDef.json");
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      const fileContent = fs.readFileSync(filePath, "utf-8");
+      const expectedJson = {
+        simpleExternal: {
+          message: "Hello from external file!",
+        },
+      };
+      expect(JSON.parse(fileContent as string)).toEqual(expectedJson);
+    });
+
+    it("should resolve a simple $ref to an external file", async () => {
+      const doc = {
+        // $ref path is relative to the mocked CWD (/home/user/test)
+        instance: { $ref: "test/fixtures/externalDef.json#/simpleExternal" },
+      };
+      const resolved = await resolvePact(doc);
+      expect(resolved.instance.message).toBe("Hello from external file!");
+    });
+
+    it("should resolve a simple $ref to an external file using file:// URI", async () => {
+      // Construct an absolute path for memfs
+      const absoluteFilePath = path.join(
+        CWD,
+        "test",
+        "fixtures",
+        "externalDef.json"
+      );
+      // Create a file URI. Note: path.join handles platform-specific separators.
+      // For file URIs, forward slashes are standard. Node's url.pathToFileURL is robust.
+      const fileUri = url.pathToFileURL(absoluteFilePath).href;
+
+      const doc = {
+        instance: { $ref: `${fileUri}#/simpleExternal` },
+      };
+      const resolved = await resolvePact(doc);
+      expect(resolved.instance.message).toBe("Hello from external file!");
+    });
+
+    it("should resolve a parameterized $ref to an external file", async () => {
+      const doc = {
+        instance: {
+          // $ref path is relative to the mocked CWD
+          $ref: "test/fixtures/externalParameterizedDef.json#/parameterizedExternal?name=Galaxy&value=123",
+        },
+      };
+      const resolved = await resolvePact(doc);
+      expect(resolved.instance.greeting).toBe(
+        "Greetings, Galaxy, from an external source!"
+      );
+      expect(resolved.instance.detail).toBe("Your value is 123.");
+    });
+
+    it("should resolve an external $ref that points to another external file (relative path)", async () => {
+      const doc = {
+        instance: {
+          // $ref path is relative to the mocked CWD
+          $ref: "test/fixtures/externalRefToExternal.json#/externalContainer",
+        },
+      };
+      const resolved = await resolvePact(doc);
+      expect(resolved.instance.name).toBe("Container for another external def");
+      expect(resolved.instance.containedDef.message).toBe(
+        "Hello from external file!"
+      );
+    });
+  });
+});

--- a/src/shared/c8ypact/c8yresolver.ts
+++ b/src/shared/c8ypact/c8yresolver.ts
@@ -3,6 +3,7 @@ import { URLSearchParams } from "url";
 
 import lodash1 from "lodash";
 import * as lodash2 from "lodash";
+import { C8yPact } from "./c8ypact";
 const _ = lodash1 || lodash2;
 
 interface RefParameterizationInfo {
@@ -129,7 +130,7 @@ function replacePlaceholdersInCopy(
   return target; // For numbers, booleans, null, undefined
 }
 
-export async function resolvePact(doc: any): Promise<any> {
+export async function resolvePact(doc: any): Promise<C8yPact | null> {
   if (doc == null || typeof doc !== "object") {
     return doc;
   }
@@ -167,5 +168,6 @@ export async function resolvePact(doc: any): Promise<any> {
     }
   }
 
-  return finalDoc;
+  const pact = _.pick(finalDoc, "records", "info", "id") as C8yPact;
+  return pact;
 }

--- a/src/shared/c8ypact/c8yresolver.ts
+++ b/src/shared/c8ypact/c8yresolver.ts
@@ -1,0 +1,145 @@
+import $RefParser from "@apidevtools/json-schema-ref-parser";
+import { URLSearchParams } from "url";
+
+import lodash1 from "lodash";
+import * as lodash2 from "lodash";
+const _ = lodash1 || lodash2;
+
+interface RefParameterizationInfo {
+  // Path to the property in the document that, after dereferencing, will hold the resolved content.
+  keyPath: (string | number)[];
+  params: Record<string, string>;
+  originalRefValue: string; // For debugging/context
+}
+
+// Helper: Recursively find $ref properties, normalize them, and collect parameterization info.
+// Modifies the documentNode in place.
+function traverseAndPreprocessRefs(
+  currentNode: any,
+  currentPath: (string | number)[], // Path to the currentNode
+  collectedParams: RefParameterizationInfo[]
+): void {
+  if (typeof currentNode !== "object" || currentNode === null) {
+    return;
+  }
+
+  for (const key in currentNode) {
+    if (Object.prototype.hasOwnProperty.call(currentNode, key)) {
+      const value = currentNode[key];
+
+      if (key === "$ref" && _.isString(value)) {
+        const queryIndex = value.indexOf("?");
+
+        if (queryIndex !== -1) {
+          // Query parameters are present
+          const baseRef = value.substring(0, queryIndex);
+          const queryString = value.substring(queryIndex + 1);
+
+          const params: Record<string, string> = {};
+          new URLSearchParams(queryString).forEach((paramValue, paramKey) => {
+            params[paramKey] = paramValue;
+          });
+
+          collectedParams.push({
+            keyPath: [...currentPath], // Path to the object containing this $ref
+            params,
+            originalRefValue: value, // Store the original $ref with its parameters
+          });
+          // Update the $ref in the document to its base form (without parameters)
+          currentNode[key] = baseRef;
+        }
+        // If queryIndex === -1 (no query parameters), the $ref string 'value'
+        // in currentNode[key] is left untouched, fulfilling "keep $ref as is".
+        // No conversion to file:// URI or other alteration of the base $ref path occurs.
+      } else if (typeof value === "object") {
+        const nextPathSegment = Array.isArray(currentNode)
+          ? parseInt(key)
+          : key;
+        traverseAndPreprocessRefs(
+          value,
+          [...currentPath, nextPathSegment],
+          collectedParams
+        );
+      }
+    }
+  }
+}
+
+// Helper: Get value from object by path using lodash
+function getValueByPath(obj: any, path: (string | number)[]): any {
+  return _.get(obj, path);
+}
+
+// Helper: Set value in object by path using lodash
+function setValueByPath(obj: any, path: (string | number)[], value: any): void {
+  _.set(obj, path, value);
+}
+
+// Helper: Replace placeholders in a copy of the target
+function replacePlaceholdersInCopy(
+  target: any,
+  params: Record<string, string>
+): any {
+  if (_.isString(target)) {
+    let result = target;
+    for (const key in params) {
+      if (Object.prototype.hasOwnProperty.call(params, key)) {
+        const placeholder = `{{${key}}}`;
+        result = result.split(placeholder).join(params[key]); // Basic global replacement
+      }
+    }
+    return result;
+  } else if (Array.isArray(target)) {
+    return target.map((item) => replacePlaceholdersInCopy(item, params));
+  } else if (typeof target === "object" && target !== null) {
+    const copy: { [key: string]: any } = {}; // Create a new object
+    for (const key in target) {
+      if (Object.prototype.hasOwnProperty.call(target, key)) {
+        copy[key] = replacePlaceholdersInCopy(target[key], params);
+      }
+    }
+    return copy;
+  }
+  return target; // For numbers, booleans, null, undefined
+}
+
+export async function resolvePact(doc: any): Promise<any> {
+  if (doc == null || typeof doc !== "object") {
+    return doc;
+  }
+
+  const parameterizationInfoList: RefParameterizationInfo[] = [];
+  // Work on a deep clone for preprocessing to avoid modifying the original input `doc`
+  const docForProcessing = _.cloneDeep(doc);
+
+  // 1. Custom "parsing" step: Traverse and modify $refs, collect parameterization info
+  traverseAndPreprocessRefs(docForProcessing, [], parameterizationInfoList);
+
+  // 2. Dereference using the standard mechanism with the preprocessed document
+  const dereferencedDoc = await $RefParser.dereference(docForProcessing, {
+    dereference: {
+      // Handles circular references by replacing them with a placeholder
+      circular: "ignore",
+    },
+  });
+
+  // 3. Post-Dereferencing Replacement
+  // Operate on a clone of the dereferenced doc for the final output to ensure no side effects
+  const finalDoc = _.cloneDeep(dereferencedDoc);
+
+  for (const info of parameterizationInfoList) {
+    // info.keyPath points to the object that *contained* the $ref.
+    // This path in finalDoc should now hold the fully resolved (but not yet parameterized) content.
+    const resolvedValueAtPath = getValueByPath(finalDoc, info.keyPath);
+
+    if (typeof resolvedValueAtPath !== "undefined") {
+      const replacedAndFinalValue = replacePlaceholdersInCopy(
+        resolvedValueAtPath,
+        info.params
+      );
+      setValueByPath(finalDoc, info.keyPath, replacedAndFinalValue);
+    }
+  }
+
+  return finalDoc;
+}


### PR DESCRIPTION
Use `$ref` for referencing json objects defined within the same or external json document. This allows reuse of json objects in C8yPact documents. 