### PR TITLE
fix: adjust disableCookieBanner to also work in case there are no public-options available

### DIFF
--- a/src/lib/commands/general.ts
+++ b/src/lib/commands/general.ts
@@ -175,7 +175,10 @@ Cypress.Commands.add("disableCookieBanner", () => {
     },
     (req) => {
       req.continue((res) => {
-        res.body.cookieBanner = undefined;
+        // in case of e.g. a 404 on the public options, do not try to modify the body
+        if (res.statusCode == 200 && typeof res.body === "object") {
+          res.body.cookieBanner = undefined;
+        }
         res.send();
       });
     }


### PR DESCRIPTION
In case of a 404 response for the public options, you otherwise end up with an error like this:
```
TypeError: Cannot create property 'cookieBanner' on string '<html>
<head><title>404 Not Found</title></head>
<body bgcolor="white">
<center><h1>404 Application Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
'
```